### PR TITLE
Tweak release layout

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -39,3 +39,7 @@ implemented but it's good to have a list of ideas.
 - option to change PR/Issue/Commit links to use the GitHub autolink syntax
   instead of explicitly linking to the GitHub page.
 - delete extra line-breaks from end of generated file.
+- when we finally sort the PRs for each release by tag, put the
+  'dependency'-tagged PR's in a collapsable list at the bottom of the release,
+  to avoid cluttering the changelog with a bunch of Dependabot PRs.
+- offer the ability to collapse other sections (or all sections) too.

--- a/github_changelog_md/changelog/changelog.py
+++ b/github_changelog_md/changelog/changelog.py
@@ -97,12 +97,12 @@ class ChangeLog:
 
             for release in self.repo_releases:
                 if prev_release:
-                    self.get_diff_url(f, prev_release, release)
+                    self.generate_diff_url(f, prev_release, release)
                 f.write(
                     f"## [{release.tag_name}]({release.html_url}) "
                     f"({release.created_at.date()})\n\n"
                 )
-                if release.title != release.tag_name:
+                if release.title != release.tag_name and release.title:
                     f.write(f"### {release.title}\n\n")
                 pr_list: List[PullRequest] = self.pr_by_release.get(
                     release.id, []
@@ -128,7 +128,7 @@ class ChangeLog:
             f"[bold]{Path.cwd() / 'CHANGELOG.md'}[/bold]\n"
         )
 
-    def get_diff_url(
+    def generate_diff_url(
         self,
         f,
         prev_release: Union[GitRelease, str],

--- a/github_changelog_md/changelog/changelog.py
+++ b/github_changelog_md/changelog/changelog.py
@@ -100,7 +100,7 @@ class ChangeLog:
                     self.get_diff_url(f, prev_release, release)
                 f.write(
                     f"## [{release.tag_name}]({release.html_url}) "
-                    f"({release.created_at.date()})\n"
+                    f"({release.created_at.date()})\n\n"
                 )
                 if release.title != release.tag_name:
                     f.write(f"### {release.title}\n\n")
@@ -109,7 +109,9 @@ class ChangeLog:
                 )
                 if len(pr_list) > 0:
                     self.print_prs(f, pr_list)
-                    prev_release = release
+                else:
+                    f.write(release.body)
+                prev_release = release
 
         print(self.done_str)
         print(

--- a/github_changelog_md/changelog/changelog.py
+++ b/github_changelog_md/changelog/changelog.py
@@ -119,6 +119,8 @@ class ChangeLog:
                             body_lines.pop(i)
                             break
                     body = "\n".join(body_lines)
+                    if body[-2] != "\n":
+                        body += "\n"
                     f.write(body)
                 prev_release = release
 

--- a/github_changelog_md/changelog/changelog.py
+++ b/github_changelog_md/changelog/changelog.py
@@ -5,7 +5,7 @@ This will encapsulate the logic for generating the changelog.
 from __future__ import annotations
 
 from pathlib import Path
-from typing import TYPE_CHECKING, Dict, List, Optional, Union
+from typing import TYPE_CHECKING, Dict, List, Literal, Optional, Union
 
 import typer  # pylint: disable=redefined-builtin
 from github import Auth, Github, GithubException
@@ -85,7 +85,7 @@ class ChangeLog:
             mode="w", encoding="utf-8"
         ) as f:
             f.write("# Changelog\n\n")
-            prev_release = None
+            prev_release: Union[GitRelease, Literal["HEAD"], None] = None
 
             if len(self.unreleased) > 0:
                 f.write(
@@ -135,7 +135,7 @@ class ChangeLog:
         f,
         prev_release: Union[GitRelease, str],
         release_tag: GitRelease,
-    ):
+    ) -> None:
         """Generate a GitHub 3-dots link to the diff between two releases."""
         if isinstance(prev_release, GitRelease):
             prev_release = prev_release.tag_name

--- a/github_changelog_md/changelog/changelog.py
+++ b/github_changelog_md/changelog/changelog.py
@@ -110,7 +110,16 @@ class ChangeLog:
                 if len(pr_list) > 0:
                     self.print_prs(f, pr_list)
                 else:
-                    f.write(release.body)
+                    # first remove any existing diff links so we can add our
+                    # own. The auto-generated release notes on GitHub will
+                    # add a diff link to the release notes. We don't want that.
+                    body_lines = release.body.split("\n")
+                    for i, line in enumerate(body_lines):
+                        if f"{self.repo_data.html_url}/compare/" in line:
+                            body_lines.pop(i)
+                            break
+                    body = "\n".join(body_lines)
+                    f.write(body)
                 prev_release = release
 
         print(self.done_str)
@@ -258,4 +267,5 @@ class ChangeLog:
                 "  [green]->[/green] Repository : "
                 f"[bold]{repo_data.full_name}[/bold]"
             )
+            return repo_data
             return repo_data

--- a/github_changelog_md/changelog/changelog.py
+++ b/github_changelog_md/changelog/changelog.py
@@ -100,8 +100,10 @@ class ChangeLog:
                     self.get_diff_url(f, prev_release, release)
                 f.write(
                     f"## [{release.tag_name}]({release.html_url}) "
-                    f"({release.created_at.date()})\n\n"
+                    f"({release.created_at.date()})\n"
                 )
+                if release.title != release.tag_name:
+                    f.write(f"### {release.title}\n\n")
                 pr_list: List[PullRequest] = self.pr_by_release.get(
                     release.id, []
                 )


### PR DESCRIPTION
Some changes to each release:

- add the release title (if it exists) under the main tag line
- if there are no linked PRs or Issues and the release would be otherwise blank, show the release description instead
- remove the 3-dot link if it exists in the description as we add our own