### PR TITLE
Sort prs into sections based on their labels

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -13,7 +13,7 @@ implemented but it's good to have a list of ideas.
   (allows user customization to the CHANGELOG).
 - Ability to specify a custom CHANGELOG file (e.g. `HISTORY.md` or
   `CHANGES.md`).
-- Ability to specify a custom template file (e.g. `changelog.jinja`).
+- Ability to specify a custom template layout.
 - Ability to upload the CHANGELOG to a remote server.
 - Allow filtering of commits based on commit message or other criteria.
 - Allow customization of the commit message format in the changelog.
@@ -22,8 +22,6 @@ implemented but it's good to have a list of ideas.
   week, last month, etc.)
 - Add support for generating changelogs for specific contributors, authors or
   teams.
-- option to include the release body in the changelog, default to false since we
-  can probably generate a better changelog than the release body.
 - include closed issues in the changelog, linked to the PR that closed them.
 - add ability to create a new release on GitHub with the latest changelog text
   as the body.
@@ -35,11 +33,17 @@ implemented but it's good to have a list of ideas.
   explain changes in the version numbering scheme or other important
   information.
 - if there are no PR for a specific release then say something to that effect
-  instead of just leaving the section empty.
+  instead of just leaving the section empty. We already use the Release 'body'
+  for this, but if that is missing too we need to say something.
 - option to change PR/Issue/Commit links to use the GitHub autolink syntax
   instead of explicitly linking to the GitHub page.
 - delete extra line-breaks from end of generated file.
-- when we finally sort the PRs for each release by tag, put the
-  'dependency'-tagged PR's in a collapsable list at the bottom of the release,
-  to avoid cluttering the changelog with a bunch of Dependabot PRs.
-- offer the ability to collapse other sections (or all sections) too.
+- put the 'dependency'-tagged PR's in a collapsable list at the bottom of the
+  release, to avoid cluttering the changelog with a bunch of Dependabot PRs.
+  _**[`This would be very useful however it breaks loading the CHANGELOG directly
+  into MkDocs as it marks this up as a collapsable boxed section and mangles the
+  formatting.`]**_
+- offer the ability to collapse other sections (or all sections) too. _**[`See
+  Above`]**_
+- escape any 'dunder' strings in the PR title, e.g. `__init__` or `__main__` as
+  otherwise they will be interpreted as markdown and made BOLD.

--- a/github_changelog_md/changelog/changelog.py
+++ b/github_changelog_md/changelog/changelog.py
@@ -114,7 +114,7 @@ class ChangeLog:
             f"({release.created_at.date()})\n\n"
         )
         if release.title != release.tag_name and release.title:
-            f.write(f"### {release.title}\n\n")
+            f.write(f"**_'{release.title}'_**\n\n")
         pr_list: List[PullRequest] = self.pr_by_release.get(release.id, [])
         if len(pr_list) > 0:
             self.print_prs(f, pr_list)
@@ -175,7 +175,7 @@ class ChangeLog:
 
         for heading, prs in release_sections.items():
             if len(prs) > 0:
-                f.write(f"### {heading}\n\n")
+                f.write(f"**{heading}**\n\n")
                 for pr in prs[::-1]:
                     f.write(
                         f"- {pr.title}\n"

--- a/github_changelog_md/changelog/changelog.py
+++ b/github_changelog_md/changelog/changelog.py
@@ -13,7 +13,7 @@ from github.GitRelease import GitRelease
 from rich import print
 
 from github_changelog_md.config import settings
-from github_changelog_md.constants import ExitErrors
+from github_changelog_md.constants import SECTIONS, ExitErrors
 from github_changelog_md.helpers import header
 
 if TYPE_CHECKING:
@@ -150,18 +150,39 @@ class ChangeLog:
     def print_prs(self, f: TextIOWrapper, pr_list: List[PullRequest]) -> None:
         """Print all the PRs for a given release.
 
-        This will be expanded soon to include the issues as well, and will
-        sort the PRs by type (enhancement, bugfix, etc) based on their label.
-
-        For now it just prints the PRs with the latest PR first.
+        They are sorted into sections depending on the labels they have.
         """
-        for pr in pr_list[::-1]:
-            f.write(
-                f"- {pr.title}\n"
-                f"([#{pr.number}]({pr.html_url}))\n"
-                f"by **[{pr.user.login}]({pr.user.html_url})**\n"
+        release_sections = {
+            heading: [
+                pr
+                for pr in pr_list
+                if label in [label.name for label in pr.labels]
+            ]
+            for heading, label in SECTIONS
+        }
+
+        # default section for PRs that don't have any of the specific labels we
+        # have defined for section headings. This may be able to be merged with
+        # the above dict comprehension?
+        release_sections["Merged Pull Requests"] = [
+            pr
+            for pr in pr_list
+            if not any(
+                label in [label.name for label in pr.labels]
+                for _, label in SECTIONS
             )
-        f.write("\n")
+        ]
+
+        for heading, prs in release_sections.items():
+            if len(prs) > 0:
+                f.write(f"### {heading}\n\n")
+                for pr in prs[::-1]:
+                    f.write(
+                        f"- {pr.title}\n"
+                        f"([#{pr.number}]({pr.html_url}))\n"
+                        f"by [{pr.user.login}]({pr.user.html_url})\n"
+                    )
+                f.write("\n")
 
     def link_pull_requests(self) -> Dict[int, List[PullRequest]]:
         """Link Pull Requests to their respective Release.

--- a/github_changelog_md/constants.py
+++ b/github_changelog_md/constants.py
@@ -1,5 +1,8 @@
 """Define constants used throughout the application."""
 from enum import IntEnum
+from typing import List, Tuple, TypeAlias, Union
+
+SectionHeadings: TypeAlias = Tuple[str, Union[str, None]]
 
 
 class ExitErrors(IntEnum):
@@ -13,3 +16,13 @@ class ExitErrors(IntEnum):
     USER_ABORT = 3
     OS_ERROR = 4
     INVALID_ACTION = 5
+
+
+SECTIONS: List[SectionHeadings] = [
+    ("Merged Pull Requests", None),
+    ("Enhancements", "enhancement"),
+    ("Bug Fixes", "bug"),
+    ("Refactoring", "refactor"),
+    ("Documentation", "documentation"),
+    ("Dependency Updates", "dependencies"),
+]


### PR DESCRIPTION
The default (headings, label) are:

```python
SECTIONS: List[SectionHeadings] = [
    ("Merged Pull Requests", None),
    ("Enhancements", "enhancement"),
    ("Bug Fixes", "bug"),
    ("Refactoring", "refactor"),
    ("Documentation", "documentation"),
    ("Dependency Updates", "dependencies"),
]
```

In that order.