### PR TITLE
Get repo name from local if possible

### DIFF
--- a/github_changelog_md/changelog/changelog.py
+++ b/github_changelog_md/changelog/changelog.py
@@ -105,7 +105,12 @@ class ChangeLog:
             f"[bold]{Path.cwd() / 'CHANGELOG.md'}[/bold]\n"
         )
 
-    def process_release(self, f, prev_release, release):
+    def process_release(
+        self,
+        f: TextIOWrapper,
+        prev_release: Union[GitRelease, Literal["HEAD"], None],
+        release: GitRelease,
+    ) -> None:
         """Process a single release."""
         if prev_release:
             self.generate_diff_url(f, prev_release, release)
@@ -134,7 +139,7 @@ class ChangeLog:
 
     def generate_diff_url(
         self,
-        f,
+        f: TextIOWrapper,
         prev_release: Union[GitRelease, str],
         release_tag: GitRelease,
     ) -> None:

--- a/github_changelog_md/helpers.py
+++ b/github_changelog_md/helpers.py
@@ -2,6 +2,7 @@
 import sys
 from importlib import metadata, resources
 from pathlib import Path
+from typing import Union
 
 import rtoml
 from rich import print  # pylint: disable=redefined-builtin
@@ -58,3 +59,15 @@ def header() -> None:
         "\n[bold blue]GitHub Changelog Generator[/bold blue] "
         f"v{get_app_version()}\n"
     )
+
+
+def get_repo_name() -> Union[str, None]:
+    """Return the name of the repository from the current directory."""
+    git_config_path = Path.cwd() / ".git" / "config"
+    repo_name = None
+    if git_config_path.exists():
+        with Path(git_config_path).open("r", encoding="utf-8") as git_config:
+            for line in git_config:
+                if "url" in line:
+                    repo_name = Path(line.split("=")[-1]).stem
+    return repo_name

--- a/github_changelog_md/main.py
+++ b/github_changelog_md/main.py
@@ -20,8 +20,8 @@ def main(
     version: Optional[bool] = typer.Option(
         None, "-v", "--version", is_eager=True
     ),
-    repo: str = typer.Option(
-        ...,
+    repo: Optional[str] = typer.Option(
+        None,
         "--repo",
         "-r",
         help="Name of the repository to generate the changelog for.",

--- a/github_changelog_md/main.py
+++ b/github_changelog_md/main.py
@@ -5,7 +5,7 @@ import typer
 from rich import print  # pylint: disable=redefined-builtin
 
 from github_changelog_md.changelog import ChangeLog
-from github_changelog_md.helpers import get_app_version
+from github_changelog_md.helpers import get_app_version, get_repo_name
 
 app = typer.Typer(
     pretty_exceptions_show_locals=False,
@@ -44,6 +44,19 @@ def main(
             "\u00a9 Grant Ramsay 2023\n"
         )
         raise typer.Exit()
+
+    if not repo:
+        """Try to get the repo from the current directory."""
+        if not repo:
+            repo = get_repo_name()
+
+            if not repo:
+                # cant find a local repo and none specified on the cmd line.
+                print(
+                    "[red]  ->  Could not find a local repository, "
+                    "Please use the --repo option.\n"
+                )
+                raise typer.Exit()
 
     cl = ChangeLog(repo, user)
     cl.run()


### PR DESCRIPTION
If we are run from a local repository (and `--repo` is **NOT** specified), try first to get the name from that, terminating with a message if not possible. 

If the `--repo` flag is specified on the command line that will always take precedence though. 