### PR TITLE
Add the '--next-release' option

### DIFF
--- a/github_changelog_md/changelog/changelog.py
+++ b/github_changelog_md/changelog/changelog.py
@@ -4,6 +4,7 @@ This will encapsulate the logic for generating the changelog.
 """
 from __future__ import annotations
 
+from datetime import date
 from pathlib import Path
 from typing import TYPE_CHECKING, Dict, List, Literal, Optional, Union
 
@@ -40,13 +41,19 @@ class ChangeLog:
 
     done_str = "[green]Done[/green]"
 
-    def __init__(self, repo_name: str, user_name: Optional[str] = None) -> None:
+    def __init__(
+        self,
+        repo_name: str,
+        user_name: Optional[str] = None,
+        next_release: Optional[str] = None,
+    ) -> None:
         """Initialize the class."""
         self.auth = Auth.Token(settings.github_pat)
         self.git = Github(auth=self.auth)
 
         self.repo_name: str = repo_name
         self.user: Optional[str] = user_name
+        self.next_release: Optional[str] = next_release
 
         self.repo_data: Repository
         self.repo_releases: List[GitRelease]
@@ -88,9 +95,14 @@ class ChangeLog:
             prev_release: Union[GitRelease, Literal["HEAD"], None] = None
 
             if len(self.unreleased) > 0:
+                heading = (
+                    self.next_release if self.next_release else "Unreleased"
+                )
+                release_date = f" ({date.today()})" if self.next_release else ""
                 f.write(
-                    f"## [Unreleased]({self.repo_data.html_url}"
-                    "/tree/HEAD)\n\n"
+                    f"## [{heading}]({self.repo_data.html_url}"
+                    "/tree/HEAD)"
+                    f"{release_date}\n\n"
                 )
                 self.print_prs(f, self.unreleased)
                 prev_release = "HEAD"

--- a/github_changelog_md/main.py
+++ b/github_changelog_md/main.py
@@ -34,6 +34,13 @@ def main(
         help="Name of the user or organisation that owns the repository.",
         show_default=False,
     ),
+    next_release: Optional[str] = typer.Option(
+        None,
+        "--next-release",
+        "-n",
+        help="Name of the next release to generate the changelog for.",
+        show_default=False,
+    ),
 ) -> None:
     """Generate your CHANGELOG file Automatically."""
     if version:
@@ -58,7 +65,7 @@ def main(
                 )
                 raise typer.Exit()
 
-    cl = ChangeLog(repo, user)
+    cl = ChangeLog(repo, user, next_release)
     cl.run()
 
 

--- a/github_changelog_md/main.py
+++ b/github_changelog_md/main.py
@@ -42,7 +42,12 @@ def main(
         show_default=False,
     ),
 ) -> None:
-    """Generate your CHANGELOG file Automatically."""
+    """Generate your CHANGELOG file Automatically.
+
+    If you don't specify a repository name, the application will try to
+    get the repository name from the current directory (assuming it is a git
+    repository).
+    """
     if version:
         print(
             "\n[green]Github Changelog Markdown - "

--- a/poetry.lock
+++ b/poetry.lock
@@ -2486,4 +2486,4 @@ testing = ["big-O", "jaraco.functools", "jaraco.itertools", "more-itertools", "p
 [metadata]
 lock-version = "2.0"
 python-versions = ">=3.9,<4.0"
-content-hash = "eafcbdc275524b293e4747b9ad6616e1d9cc697af7f8bc19660486cfae10f005"
+content-hash = "99b39a20245b073e23a91957c7b6dca9b4dffb8aada28bc8f0b1179f1bf541f4"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,7 +24,6 @@ github-changelog-md = "github_changelog_md.main:app"
 
 [tool.poetry.dependencies]
 python = ">=3.9,<4.0"
-gitpython = "^3.1.37"
 pygithub = ">=1.59.1,<3.0.0"
 pydantic = "^2.3.0"
 simple-toml-settings = "^0.3.0"


### PR DESCRIPTION
Allows creating a CHANGELOG for a release that does not exist on GitHub.

Useful to prepare for an upcoming release.