### PR TITLE
Fix bug in release links when 'next release' is specified

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## [0.2.1](https://github.com/seapagan/github-changelog-md/tree/HEAD) (2023-10-22)
+## [0.2.1](https://github.com/seapagan/github-changelog-md/tree/0.2.1) (2023-10-22)
 
 **Merged Pull Requests**
 
@@ -17,7 +17,7 @@ by [seapagan](https://github.com/seapagan)
 ([#44](https://github.com/seapagan/github-changelog-md/pull/44))
 by [dependabot[bot]](https://github.com/apps/dependabot)
 
-[`Full Changelog`](https://github.com/seapagan/github-changelog-md/compare/0.2.0...HEAD)
+[`Full Changelog`](https://github.com/seapagan/github-changelog-md/compare/0.2.0...0.2.1)
 
 ## [0.2.0](https://github.com/seapagan/github-changelog-md/releases/tag/0.2.0) (2023-10-21)
 

--- a/github_changelog_md/changelog/changelog.py
+++ b/github_changelog_md/changelog/changelog.py
@@ -108,8 +108,8 @@ class ChangeLog:
                     else ""
                 )
                 f.write(
-                    f"## [{heading}]({self.repo_data.html_url}"
-                    "/tree/HEAD)"
+                    f"## [{heading}]({self.repo_data.html_url}/tree/"
+                    f"{'HEAD' if not self.next_release else self.next_release})"
                     f"{release_date}\n\n",
                 )
 
@@ -194,6 +194,8 @@ class ChangeLog:
         """Generate a GitHub 3-dots link to the diff between two releases."""
         if isinstance(prev_release, GitRelease):
             prev_release = prev_release.tag_name
+        elif self.next_release:
+            prev_release = self.next_release
         f.write(
             f"[`Full Changelog`]"
             f"({self.repo_data.html_url}/compare/"


### PR DESCRIPTION
When the `--next-release` flag is used, the links in the release header and full changelog still point to `HEAD` which is wrong, they need to point to the proper (next) release even though it does not yet exist.