### PR TITLE
fix another bug with 'next-release' links

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## [0.2.1](https://github.com/seapagan/github-changelog-md/tree/0.2.1) (2023-10-22)
+## [0.2.1](https://github.com/seapagan/github-changelog-md/releases/tag/0.2.1) (2023-10-22)
 
 **Merged Pull Requests**
 

--- a/github_changelog_md/changelog/changelog.py
+++ b/github_changelog_md/changelog/changelog.py
@@ -107,9 +107,13 @@ class ChangeLog:
                     if self.next_release
                     else ""
                 )
+                release_link = (
+                    "tree/HEAD"
+                    if not self.next_release
+                    else f"releases/tag/{self.next_release}"
+                )
                 f.write(
-                    f"## [{heading}]({self.repo_data.html_url}/tree/"
-                    f"{'HEAD' if not self.next_release else self.next_release})"
+                    f"## [{heading}]({self.repo_data.html_url}/{release_link}"
                     f"{release_date}\n\n",
                 )
 


### PR DESCRIPTION
The release title link needs to be re-written to point to the `release` not the `tag`