### PR TITLE
Trim PR and Issue titles in changelog

### DIFF
--- a/github_changelog_md/changelog/changelog.py
+++ b/github_changelog_md/changelog/changelog.py
@@ -156,7 +156,7 @@ class ChangeLog:
             f"({release.created_at.date()})\n\n",
         )
         if release.title != release.tag_name and release.title:
-            f.write(f"**_'{release.title}'_**\n\n")
+            f.write(f"**_'{release.title.strip()}'_**\n\n")
         pr_list: list[PullRequest] = self.pr_by_release.get(release.id, [])
         issue_list: list[Issue] = self.issue_by_release.get(release.id, [])
 
@@ -182,7 +182,7 @@ class ChangeLog:
         """Print all the closed issues for a given release."""
         f.write("**Closed Issues**\n\n")
         for issue in issue_list:
-            escaped_title = issue.title.replace("__", "\\_\\_")
+            escaped_title = issue.title.replace("__", "\\_\\_").strip()
             f.write(
                 f"- {escaped_title}\n"
                 f"([#{issue.number}]({issue.html_url}))\n"
@@ -237,7 +237,7 @@ class ChangeLog:
             if len(prs) > 0:
                 f.write(f"**{heading}**\n\n")
                 for pr in prs[::-1]:
-                    escaped_title = pr.title.replace("__", "\\_\\_")
+                    escaped_title = pr.title.replace("__", "\\_\\_").strip()
                     f.write(
                         f"- {escaped_title}\n"
                         f"([#{pr.number}]({pr.html_url}))\n"


### PR DESCRIPTION
If titles have spaces at the start or end, it is not generally noticed when rendered, but it does annoy Markdown Linters.