### PR TITLE
add and implement '--unreleased' option

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -57,5 +57,3 @@ implemented but it's good to have a list of ideas.
   block to the release?
 - Add an option to add a custom text block to the top of the changelog, eg to
   explain the version numbering scheme or other important information.
-- Add an option to hide any unreleased changes from the changelog, eg to only
-  show changes for the latest release.

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -41,7 +41,7 @@ file will be created in the current folder if it does not already exist.
 
 There are some options you can use to customize the output of the tool.
 
-### `--next-release` \ `-n`
+### `--next-release` / `-n`
 
 This option allows you to specify the name of the next release. By default, any
 PRs that are merged after the last existing release will be added to the
@@ -55,8 +55,13 @@ Useful to prep for a release before it is actually released.
 $ github-changelog-md --next-release 1.2.3
 ```
 
+### `--released` / `--no-unreleased`
+
+Choose whether to include the `Unreleased` section in the changelog. By default
+the `Unreleased` section is included (`--released`), but you can use the
+`--no-unreleased` option to exclude it
+
 ## Future plans
 
-At this time the tool does not have many options or configuration, but in the
-future we plan to add a lot of options to customize the output. See the [Todo
-List](todo_list.md) for planned features.
+See the [Todo List](todo_list.md) for planned features. There are quite a few
+more options and customizations to come.

--- a/github_changelog_md/changelog/changelog.py
+++ b/github_changelog_md/changelog/changelog.py
@@ -46,6 +46,7 @@ class ChangeLog:
         repo_name: str,
         user_name: Optional[str] = None,
         next_release: Optional[str] = None,
+        unreleased: Optional[bool] = True,
     ) -> None:
         """Initialize the class."""
         self.auth = Auth.Token(get_settings().github_pat)
@@ -54,6 +55,7 @@ class ChangeLog:
         self.repo_name: str = repo_name
         self.user: str | None = user_name
         self.next_release: str | None = next_release
+        self.show_unreleased: bool | None = unreleased
 
         self.repo_data: Repository
         self.repo_releases: list[GitRelease]
@@ -98,7 +100,8 @@ class ChangeLog:
             f.write("# Changelog\n\n")
             self.prev_release: GitRelease | (Literal["HEAD"] | None) = None
 
-            self.process_unreleased(f)
+            if self.show_unreleased:
+                self.process_unreleased(f)
 
             for release in self.repo_releases:
                 self.process_release(f, release)

--- a/github_changelog_md/main.py
+++ b/github_changelog_md/main.py
@@ -46,6 +46,11 @@ def main(
         help="Name of the next release to generate the changelog for.",
         show_default=False,
     ),
+    unreleased: Optional[bool] = typer.Option(
+        default=True,
+        help="Show unreleased changes in the changelog.",
+        show_default=True,
+    ),
 ) -> None:
     """Generate your CHANGELOG file Automatically.
 
@@ -75,5 +80,5 @@ def main(
                 )
                 raise typer.Exit
 
-    cl = ChangeLog(repo, user, next_release)
+    cl = ChangeLog(repo, user, next_release, unreleased)
     cl.run()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -117,16 +117,22 @@ omit = ["*/tests/*"]
 
 [tool.ruff]
 line-length = 80
-select = ["ALL"]              # we are being very strict!
-ignore = ["ANN101", "PGH003"] # These rules are too strict even for us 😝
+select = ["ALL"] # we are being very strict!
+ignore = [
+  "ANN101",
+  "PGH003",
+  "FBT002",
+  "FBT003",
+] # These rules are too strict even for us 😝
 src = ["github_changelog_md"]
-target-version = "py39"       # minimum python version supported
+target-version = "py39" # minimum python version supported
 
 [tool.ruff.pep8-naming]
 classmethod-decorators = ["pydantic.validator", "pydantic.root_validator"]
 
 [tool.ruff.pydocstyle]
 convention = "google"
+
 
 [tool.ruff.extend-per-file-ignores]
 "tests/**/*.py" = [

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -36,7 +36,12 @@ class TestMain:
 
         runner = CliRunner()
         runner.invoke(app, ["--repo", "test_repo"])
-        mock_changelog.assert_called_once_with("test_repo", None, None)
+        mock_changelog.assert_called_once_with(
+            "test_repo",
+            None,
+            None,
+            True,
+        )
         mock_changelog_instance.run.assert_called_once()
 
     def test_main_with_repo_and_user(self, mock_changelog: MockType) -> None:
@@ -46,7 +51,12 @@ class TestMain:
 
         runner = CliRunner()
         runner.invoke(app, ["--repo", "test_repo", "--user", "test_user"])
-        mock_changelog.assert_called_once_with("test_repo", "test_user", None)
+        mock_changelog.assert_called_once_with(
+            "test_repo",
+            "test_user",
+            None,
+            True,
+        )
         mock_changelog_instance.run.assert_called_once()
 
     def test_main_with_repo_and_user_and_next_release(
@@ -69,7 +79,12 @@ class TestMain:
                 "v1.0",
             ],
         )
-        mock_changelog.assert_called_once_with("test_repo", "test_user", "v1.0")
+        mock_changelog.assert_called_once_with(
+            "test_repo",
+            "test_user",
+            "v1.0",
+            True,
+        )
         mock_changelog_instance.run.assert_called_once()
 
     def test_no_repo_specified_get_from_local_repo(
@@ -91,7 +106,12 @@ class TestMain:
 
         runner = CliRunner()
         runner.invoke(app)
-        mock_changelog.assert_called_once_with("test_local_repo", None, None)
+        mock_changelog.assert_called_once_with(
+            "test_local_repo",
+            None,
+            None,
+            True,
+        )
         mock_changelog_instance.run.assert_called_once()
 
     def test_no_repo_specified_and_no_local_repo_found(


### PR DESCRIPTION
By default `--unreleased` is true so any unreleased PRs will be shown in their own section. Using the `--no-unreleased` option stops that