### PR TITLE
Hide dependency PRs if requested

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -4,7 +4,7 @@
       "source.fixAll": "always",
       "source.organizeImports": "always"
     },
-    "editor.defaultFormatter": "ms-python.black-formatter"
+    "editor.defaultFormatter": "charliermarsh.ruff"
   },
   "autoDocstring.startOnNewLine": true,
   "beautify.language": {

--- a/TODO.md
+++ b/TODO.md
@@ -59,3 +59,7 @@ implemented but it's good to have a list of ideas.
 - check the closed issues logic - we don't want to list issues that were closed
   unless it is linked to a merged PR. Some issues will be closed as wrong or not
   relevant to a release etc, and we don't want to list those.
+- some version numbers in PRs (especially dependabot) get mis-identified as
+  emojis in the output, especially if the version number contains `<3` which
+  gives <3. This is very obvious for 'pip' version numbers. We need to escape
+  this particular pattern in the PR title.

--- a/TODO.md
+++ b/TODO.md
@@ -46,9 +46,6 @@ implemented but it's good to have a list of ideas.
   don't need to be in the changelog.
 - For using the tool in a CI/CD pipeline, allow setting the `GITHUB_PAT`
   environment variable instead of creating a config file.
-- Option to hide Dependabot PRs (or more specifically any PR with the
-  'dependency' label) from the changelog? Mention there are some, but
-  point to the full changelog for details.
 - Add a 'breaking changes' section to the release, with an optional flag to only
   show this section if there are breaking changes. This will need a specific
   GitHub label to be set on the PRs that are breaking changes. Allow to add a
@@ -59,3 +56,6 @@ implemented but it's good to have a list of ideas.
 - Add an option to add a custom text block to the top of the changelog, eg to
   explain the version numbering scheme or other important information.
 - investigate adding caching of the GitHub API calls to speed up the process.
+- check the closed issues logic - we don't want to list issues that were closed
+  unless it is linked to a merged PR. Some issues will be closed as wrong or not
+  relevant to a release etc, and we don't want to list those.

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -61,6 +61,13 @@ Choose whether to include the `Unreleased` section in the changelog. By default
 the `Unreleased` section is included (`--released`), but you can use the
 `--no-unreleased` option to exclude it
 
+### `--depends` / `--no-depends`
+
+Choose whether to include the `Dependency Updates` section in the changelog. By
+default this will be shown (`--depends`), but you can use the `--no-depends` to
+hide them. Some releases have a lot of dependency updates, so this can be useful
+to keep the changelog more readable.
+
 ## Future plans
 
 See the [Todo List](todo_list.md) for planned features. There are quite a few

--- a/github_changelog_md/changelog/changelog.py
+++ b/github_changelog_md/changelog/changelog.py
@@ -100,6 +100,13 @@ class ChangeLog:
             encoding="utf-8",
         ) as f:
             f.write("# Changelog\n\n")
+
+            if not self.options["show_depends"]:
+                f.write(
+                    "*Dependency updates are excluded from this changelog, "
+                    "check each `Full Changelog` for details.*\n\n "
+                )
+
             self.prev_release: GitRelease | (Literal["HEAD"] | None) = None
 
             if self.options["show_unreleased"]:

--- a/github_changelog_md/changelog/changelog.py
+++ b/github_changelog_md/changelog/changelog.py
@@ -16,7 +16,11 @@ from rich import print  # pylint: disable=redefined-builtin
 
 from github_changelog_md.config import get_settings
 from github_changelog_md.constants import SECTIONS, ExitErrors
-from github_changelog_md.helpers import cap_first_letter, header
+from github_changelog_md.helpers import (
+    cap_first_letter,
+    get_section_name,
+    header,
+)
 
 if TYPE_CHECKING:
     from io import TextIOWrapper
@@ -241,6 +245,11 @@ class ChangeLog:
         ]
 
         for heading, prs in release_sections.items():
+            if (
+                heading == get_section_name("dependencies")
+                and not self.options["show_depends"]
+            ):
+                continue
             if len(prs) > 0:
                 f.write(f"**{heading}**\n\n")
                 for pr in prs[::-1]:

--- a/github_changelog_md/helpers.py
+++ b/github_changelog_md/helpers.py
@@ -8,7 +8,7 @@ from pathlib import Path
 import rtoml
 from rich import print  # pylint: disable=redefined-builtin
 
-from github_changelog_md.constants import ExitErrors
+from github_changelog_md.constants import SECTIONS, ExitErrors
 
 
 def get_toml_path() -> Path:
@@ -81,3 +81,11 @@ def cap_first_letter(string: str) -> str:
     upper case letters to lower case, which is not what we want.
     """
     return string[:1].upper() + string[1:]
+
+
+def get_section_name(label: str) -> str | None:
+    """Gets a section title from a label."""
+    for section in SECTIONS:
+        if section[1] == label:
+            return section[0]
+    return None

--- a/github_changelog_md/helpers.py
+++ b/github_changelog_md/helpers.py
@@ -83,7 +83,7 @@ def cap_first_letter(string: str) -> str:
     return string[:1].upper() + string[1:]
 
 
-def get_section_name(label: str) -> str | None:
+def get_section_name(label: str | None) -> str | None:
     """Gets a section title from a label."""
     for section in SECTIONS:
         if section[1] == label:

--- a/github_changelog_md/main.py
+++ b/github_changelog_md/main.py
@@ -29,7 +29,7 @@ def main(
         None,
         "--repo",
         "-r",
-        help="Name of the repository to generate the changelog for.",
+        help="Name of the repository to generate the Changelog for.",
         show_default=False,
     ),
     user: Optional[str] = typer.Option(
@@ -48,7 +48,12 @@ def main(
     ),
     unreleased: Optional[bool] = typer.Option(
         default=True,
-        help="Show unreleased changes in the changelog.",
+        help="Show unreleased changes in the Changelog.",
+        show_default=True,
+    ),
+    depends: Optional[bool] = typer.Option(
+        default=True,
+        help="Show dependency updates in the Changelog.",
         show_default=True,
     ),
 ) -> None:
@@ -83,6 +88,7 @@ def main(
         "user_name": user,
         "next_release": next_release,
         "show_unreleased": unreleased,
+        "show_depends": depends,
     }
 
     cl = ChangeLog(repo, options)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -149,7 +149,8 @@ convention = "google"
 ]
 "github_changelog_md/main.py" = [
   "UP007",
-] # Typer is not compatible with that syntax
+  "PLR0913",
+] # These cause issues in Typer Apps
 
 [tool.ruff.isort]
 known-local-folder = ["github_changelog_md"]

--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -6,7 +6,13 @@ from pathlib import Path
 from typing import TYPE_CHECKING
 
 from github_changelog_md.constants import ExitErrors
-from github_changelog_md.helpers import get_app_version, get_repo_name, header
+from github_changelog_md.helpers import (
+    cap_first_letter,
+    get_app_version,
+    get_repo_name,
+    get_section_name,
+    header,
+)
 
 if TYPE_CHECKING:
     import pytest
@@ -112,3 +118,19 @@ class TestHelpers:
 
         assert get_app_version() is None
         assert mocked_exit.call_args[0][0] == ExitErrors.OS_ERROR
+
+    def test_cap_first_letter(self) -> None:
+        """Test cap_first_letter function."""
+        result = cap_first_letter("this IS a TeST strIng")
+        assert result == "This IS a TeST strIng"
+
+    def test_get_section_name(self) -> None:
+        """The the get_section_name function.
+
+        We just test a couple of the sections. This will break if we change any
+        of the section names, but that's what tests are for!
+        """
+        assert get_section_name("bug") == "Bug Fixes"
+        assert get_section_name("dependencies") == "Dependency Updates"
+        assert get_section_name("not_a_label") is None
+        assert get_section_name(None) == "Merged Pull Requests"

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -42,6 +42,7 @@ class TestMain:
                 "user_name": None,
                 "next_release": None,
                 "show_unreleased": True,
+                "show_depends": True,
             },
         )
         mock_changelog_instance.run.assert_called_once()
@@ -59,6 +60,7 @@ class TestMain:
                 "user_name": "test_user",
                 "next_release": None,
                 "show_unreleased": True,
+                "show_depends": True,
             },
         )
         mock_changelog_instance.run.assert_called_once()
@@ -89,6 +91,7 @@ class TestMain:
                 "user_name": "test_user",
                 "next_release": "v1.0",
                 "show_unreleased": True,
+                "show_depends": True,
             },
         )
         mock_changelog_instance.run.assert_called_once()
@@ -118,6 +121,7 @@ class TestMain:
                 "user_name": None,
                 "next_release": None,
                 "show_unreleased": True,
+                "show_depends": True,
             },
         )
         mock_changelog_instance.run.assert_called_once()


### PR DESCRIPTION
Using `--no-depends` will hide dependency PRs in the changelog. The opposite flag `--depends` is the default and does not need to be specified.