### PR TITLE
Allow a custom output file name

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -11,8 +11,6 @@ idea of where I want to take the project in the future.
 - Ability to only update changes and leave the rest of the file untouched (ie do
   not re-generate previous releases, only new ones or the unreleased section).
   (allows user customization to the CHANGELOG).
-- Ability to specify a custom CHANGELOG file (e.g. `HISTORY.md` or
-  `CHANGES.md`).
 - Ability to specify a custom template layout.
 - Ability to upload the CHANGELOG to a remote server.
 - Allow filtering of commits based on commit message or other criteria.
@@ -60,6 +58,7 @@ idea of where I want to take the project in the future.
 - check the closed issues logic - we don't want to list issues that were closed
   unless it is linked to a merged PR. Some issues will be closed as wrong or not
   relevant to a release etc, and we don't want to list those.
+- add link targets to the release headers so they can be linked to directly.
 
 ## Known Issues
 

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -41,6 +41,15 @@ file will be created in the current folder if it does not already exist.
 
 There are some options you can use to customize the output of the tool.
 
+### `--output` / `-o`
+
+By default the tool will create a `CHANGELOG.md` file in the current folder. You
+can specify a different filename using the `--output` or `-o` option.
+
+```console
+$ github-changelog-md --output HISTORY.md
+```
+
 ### `--next-release` / `-n`
 
 This option allows you to specify the name of the next release. By default, any
@@ -55,10 +64,10 @@ Useful to prep for a release before it is actually released.
 $ github-changelog-md --next-release 1.2.3
 ```
 
-### `--released` / `--no-unreleased`
+### `--unreleased` / `--no-unreleased`
 
 Choose whether to include the `Unreleased` section in the changelog. By default
-the `Unreleased` section is included (`--released`), but you can use the
+the `Unreleased` section is included (`--unreleased`), but you can use the
 `--no-unreleased` option to exclude it
 
 ### `--depends` / `--no-depends`

--- a/github_changelog_md/changelog/changelog.py
+++ b/github_changelog_md/changelog/changelog.py
@@ -95,7 +95,7 @@ class ChangeLog:
         """Generate a markdown changelog using the data we have gererated."""
         print("\n  [green]->[/green] Generating Changelog ... ", end="")
 
-        with Path(Path.cwd() / "CHANGELOG.md").open(
+        with Path(Path.cwd() / self.options["output_file"]).open(
             mode="w",
             encoding="utf-8",
         ) as f:
@@ -127,7 +127,7 @@ class ChangeLog:
         print(self.done_str)
         print(
             f"\n  [green]->[/green] Changelog generated to "
-            f"[bold]{Path.cwd() / 'CHANGELOG.md'}[/bold]\n",
+            f"[bold]{Path.cwd() / self.options['output_file']}[/bold]\n",
         )
 
     def process_unreleased(self, f: TextIOWrapper) -> None:

--- a/github_changelog_md/constants.py
+++ b/github_changelog_md/constants.py
@@ -28,3 +28,4 @@ SECTIONS: list[SectionHeadings] = [
 ]
 
 CONFIG_FILE = ".changelog_generator.toml"
+OUTPUT_FILE = "CHANGELOG.md"

--- a/github_changelog_md/main.py
+++ b/github_changelog_md/main.py
@@ -7,6 +7,7 @@ import typer
 from rich import print  # pylint: disable=redefined-builtin
 
 from github_changelog_md.changelog import ChangeLog
+from github_changelog_md.constants import OUTPUT_FILE
 from github_changelog_md.helpers import get_app_version, get_repo_name
 
 app = typer.Typer(
@@ -56,6 +57,13 @@ def main(
         help="Show dependency updates in the Changelog.",
         show_default=True,
     ),
+    output: Optional[str] = typer.Option(
+        OUTPUT_FILE,
+        "--output",
+        "-o",
+        help="Output file to write the Changelog to.",
+        show_default=False,
+    ),
 ) -> None:
     """Generate your CHANGELOG file Automatically.
 
@@ -89,6 +97,7 @@ def main(
         "next_release": next_release,
         "show_unreleased": unreleased,
         "show_depends": depends,
+        "output_file": output,
     }
 
     cl = ChangeLog(repo, options)

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -20,8 +20,17 @@ def mock_changelog(mocker: MockerFixture) -> MockType:
     return mocker.patch("github_changelog_md.main.ChangeLog")
 
 
-class TestMain:
-    """Test class for the 'main' module."""
+default_options = {
+    "user_name": None,
+    "next_release": None,
+    "show_unreleased": True,
+    "show_depends": True,
+    "output_file": "CHANGELOG.md",
+}
+
+
+class TestCLI:
+    """Test class for the CLI functionality."""
 
     def test_main_with_version(self) -> None:
         """Test the main function with the version flag."""
@@ -38,12 +47,7 @@ class TestMain:
         runner.invoke(app, ["--repo", "test_repo"])
         mock_changelog.assert_called_once_with(
             "test_repo",
-            {
-                "user_name": None,
-                "next_release": None,
-                "show_unreleased": True,
-                "show_depends": True,
-            },
+            default_options,
         )
         mock_changelog_instance.run.assert_called_once()
 
@@ -54,14 +58,11 @@ class TestMain:
 
         runner = CliRunner()
         runner.invoke(app, ["--repo", "test_repo", "--user", "test_user"])
+
+        expected_options = {**default_options, "user_name": "test_user"}
         mock_changelog.assert_called_once_with(
             "test_repo",
-            {
-                "user_name": "test_user",
-                "next_release": None,
-                "show_unreleased": True,
-                "show_depends": True,
-            },
+            expected_options,
         )
         mock_changelog_instance.run.assert_called_once()
 
@@ -85,14 +86,15 @@ class TestMain:
                 "v1.0",
             ],
         )
+
+        expected_options = {
+            **default_options,
+            "user_name": "test_user",
+            "next_release": "v1.0",
+        }
         mock_changelog.assert_called_once_with(
             "test_repo",
-            {
-                "user_name": "test_user",
-                "next_release": "v1.0",
-                "show_unreleased": True,
-                "show_depends": True,
-            },
+            expected_options,
         )
         mock_changelog_instance.run.assert_called_once()
 
@@ -115,14 +117,10 @@ class TestMain:
 
         runner = CliRunner()
         runner.invoke(app)
+
         mock_changelog.assert_called_once_with(
             "test_local_repo",
-            {
-                "user_name": None,
-                "next_release": None,
-                "show_unreleased": True,
-                "show_depends": True,
-            },
+            default_options,
         )
         mock_changelog_instance.run.assert_called_once()
 


### PR DESCRIPTION
Add the `--output` option, to choose a custom output file name. If not specified it defaults to `CHANGELOG.md`.