### PR TITLE
Don't list any PRs with '[no changelog]' in the PR title

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -31,8 +31,6 @@ idea of where I want to take the project in the future.
   information.
 - option to change PR/Issue/Commit links to use the GitHub autolink syntax
   instead of explicitly linking to the GitHub page.
-- add a flag eg \[no changelog\] to PR titles to allow skipping of PRs that
-  don't need to be in the changelog.
 - For using the tool in a CI/CD pipeline, allow setting the `GITHUB_PAT`
   environment variable instead of creating a config file.
 - Add a 'breaking changes' section to the release, with an optional flag to only

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -79,8 +79,8 @@ to keep the changelog more readable.
 
 ## Hide PR from the Changelog
 
-if there is a PR that you do **NOT** wish to include in the changelog for some
-reason, you can add `[no changelog]` anywhere in the PR title and it will be
+If there is a PR that you do **NOT** wish to include in the changelog for some
+reason, you can add `[no changelog]` anywhere in the PR title, and it will be
 excluded from the changelog. This is case-insensitive, so `[No Changelog]` or
 `[NO CHANGELOG]` will also work.
 

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -77,6 +77,13 @@ default this will be shown (`--depends`), but you can use the `--no-depends` to
 hide them. Some releases have a lot of dependency updates, so this can be useful
 to keep the changelog more readable.
 
+## Hide PR from the Changelog
+
+if there is a PR that you do **NOT** wish to include in the changelog for some
+reason, you can add `[no changelog]` anywhere in the PR title and it will be
+excluded from the changelog. This is case-insensitive, so `[No Changelog]` or
+`[NO CHANGELOG]` will also work.
+
 ## Future plans
 
 See the [Todo List](todo_list.md) for planned features. There are quite a few

--- a/github_changelog_md/changelog/changelog.py
+++ b/github_changelog_md/changelog/changelog.py
@@ -270,6 +270,8 @@ class ChangeLog:
             if len(prs) > 0:
                 f.write(f"**{heading}**\n\n")
                 for pr in prs[::-1]:
+                    if "[no changelog]" in pr.title.lower():
+                        continue
                     escaped_title = cap_first_letter(
                         pr.title.replace("__", "\\_\\_").strip(),
                     )


### PR DESCRIPTION
If there is a PR that you do **NOT** wish to include in the changelog for some reason, you can add `[no changelog]` anywhere in the PR title, and it will be excluded from the changelog. This is case-insensitive, so `[No Changelog]` or `[NO CHANGELOG]` will also work.