### PR TITLE
Add list of ignored labels

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -55,9 +55,6 @@ minor release (patch or bug-fixes are ok as needed).
   PRs.
 - :fire: change the order of PRs in the output - current is newest first, but we
   could have oldest first or alphabetical by title or something.
-- :fire: make a list of labels that are ignored, so they don't show up in the
-  output. Decent default list would be "duplicate, question, invalid, wontfix,
-  help".
 - :fire: add verbosity levels, or at least a quiet mode so it doesn't print
   anything unless there are errors.
 - :fire: add more config file options to handle some of the existing command line
@@ -65,6 +62,9 @@ minor release (patch or bug-fixes are ok as needed).
 - Add settings to run this as a GitHub action, so it can be run automatically
   when a new release is created or a PR is merged. We should be able to use the
   `secrets.GITHUB_TOKEN` for this?
+- :fire: option to skip certain releases, eg if there is a release that has been
+  yanked, we can skip it and not include it in the output.
+- :fire: option to start at a specific release, ignoring all previous releases.
 
 ## Improve existing functionality
 

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -65,6 +65,22 @@ changelog - If you are using `Dependabot`, by default it will add the
     section headers and add your own. I also plan to add the ability to use
     multiple labels for the same section, eg `enhancement` and `enhancements`
 
+## Ignored Labels
+
+There are a few labels that are ignored by default, as they should not be
+included in the changelog. These are:
+
+- `duplicate`
+- `invalid`
+- `question`
+- `wontfix`
+
+These are ignored for both PRs and Issues.
+
+!!! tip
+
+    This list of ignored labels will be customizable in future versions.
+
 ## Advanced Usage
 
 There are some options you can use to customize the output of the tool.

--- a/github_changelog_md/changelog/changelog.py
+++ b/github_changelog_md/changelog/changelog.py
@@ -15,7 +15,7 @@ from github.GitRelease import GitRelease
 from rich import print  # pylint: disable=redefined-builtin
 
 from github_changelog_md.config import get_settings
-from github_changelog_md.constants import SECTIONS, ExitErrors
+from github_changelog_md.constants import IGNORED_LABELS, SECTIONS, ExitErrors
 from github_changelog_md.helpers import (
     cap_first_letter,
     get_section_name,
@@ -205,6 +205,14 @@ class ChangeLog:
             return
         f.write("**Closed Issues**\n\n")
         for issue in issue_list:
+            if (
+                any(
+                    label.name.lower() in IGNORED_LABELS
+                    for label in issue.labels
+                )
+                or "[no changelog]" in issue.title.lower()
+            ):
+                continue
             escaped_title = cap_first_letter(
                 issue.title.replace("__", "\\_\\_").strip(),
             )
@@ -245,6 +253,10 @@ class ChangeLog:
                 pr
                 for pr in pr_list
                 if label in [label.name for label in pr.labels]
+                and not any(
+                    label in IGNORED_LABELS
+                    for label in [label.name for label in pr.labels]
+                )
             ]
             for heading, label in SECTIONS
         }
@@ -258,6 +270,10 @@ class ChangeLog:
             if not any(
                 label in [label.name for label in pr.labels]
                 for _, label in SECTIONS
+            )
+            and not any(
+                label in IGNORED_LABELS
+                for label in [label.name for label in pr.labels]
             )
         ]
 

--- a/github_changelog_md/constants.py
+++ b/github_changelog_md/constants.py
@@ -28,5 +28,13 @@ SECTIONS: list[SectionHeadings] = [
     ("Dependency Updates", "dependencies"),
 ]
 
+IGNORED_LABELS: list[str] = [
+    "duplicate",
+    "invalid",
+    "question",
+    "wontfix",
+]
+
+
 CONFIG_FILE = ".changelog_generator.toml"
 OUTPUT_FILE = "CHANGELOG.md"


### PR DESCRIPTION
This checks the PR and Issue labels against an internal list and does not add them to the created changelog if any match.

See the docs for more details. In the future, this will be configurable.