### PR TITLE
implement creating a CONTRIBUTORS file

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -3,8 +3,12 @@
 Not all of these features/ideas will (or should!) be implemented but this is an
 idea of where I want to take the project in the future.
 
-Items marked with ':fire:' should be implemented as a priority before the next
-minor release (patch or bug-fixes are ok as needed).
+Items marked with:
+
+- ':fire:' Should be implemented as a priority before the next minor release
+(patch or bug-fixes are ok as needed).
+- ':rocket:` Have been already implemented in the main repo and will be included
+in the next release.
 
 ## Features to Add
 
@@ -42,7 +46,7 @@ minor release (patch or bug-fixes are ok as needed).
 - Add an option to add a custom text block to the top of the changelog, eg to
   explain the version numbering scheme or other important information.
 - investigate adding caching of the GitHub API calls to speed up the process.
-- :fire: Option to automatically add each contributor to a 'CONTRIBUTERS.md'
+- :rocket: Option to automatically add each contributor to a 'CONTRIBUTERS.md'
   file or similar. Can use comment markers in the file to indicate where to add
   the names. Provide a default file with the comment markers in it or just
   document the process?

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -125,6 +125,23 @@ default this will be shown (`--depends`), but you can use the `--no-depends` to
 hide them. Some releases have a lot of dependency updates, so this can be useful
 to keep the changelog more readable.
 
+### `--contrib` / `--no-contrib`
+
+Choose whether to create the `CONTRIBUTORS.md` file. By default this will be
+`False` (`--no-contrib`), but you can use the `--contrib` option to enable it.
+
+!!! warning "Possibly LONG operation"
+
+    This can take a while to run, as it has to query the GitHub API for each
+    contributor. If you have a lot of contributors or many PR's, it can take a
+    few minutes to complete.
+
+    In this case it is recommended to only run this option when you are ready to
+    release a new version, and not every time you run the tool.
+
+    In future versions I will add the ability to cache the contributors list,
+    which should speed things up a lot
+
 ## Hide PR from the Changelog
 
 If there is a PR that you do **NOT** wish to include in the changelog for some

--- a/github_changelog_md/changelog/changelog.py
+++ b/github_changelog_md/changelog/changelog.py
@@ -99,9 +99,10 @@ class ChangeLog:
         # collected.
         self.generate_changelog()
 
-        # update the CONTRIBUTORS.md file
-        self.contributors = self.get_contributors()
-        self.update_contributors()
+        # update the CONTRIBUTORS.md file if requested
+        if self.options["contributors"]:
+            self.contributors = self.get_contributors()
+            self.update_contributors()
 
     def get_contributors(self) -> list[NamedUser]:
         """This will get all the contributors to the repo.
@@ -181,7 +182,7 @@ class ChangeLog:
 
         print(self.done_str)
         print(
-            f"\n  [green]->[/green] Changelog generated to "
+            f"  [green]->[/green] Changelog generated to "
             f"[bold]{Path.cwd() / self.options['output_file']}[/bold]\n",
         )
 

--- a/github_changelog_md/changelog/changelog.py
+++ b/github_changelog_md/changelog/changelog.py
@@ -15,7 +15,13 @@ from github.GitRelease import GitRelease
 from rich import print  # pylint: disable=redefined-builtin
 
 from github_changelog_md.config import get_settings
-from github_changelog_md.constants import IGNORED_LABELS, SECTIONS, ExitErrors
+from github_changelog_md.constants import (
+    CONTRIBUTORS_FILE,
+    IGNORED_CONTRIBUTORS,
+    IGNORED_LABELS,
+    SECTIONS,
+    ExitErrors,
+)
 from github_changelog_md.helpers import (
     cap_first_letter,
     get_section_name,
@@ -27,6 +33,7 @@ if TYPE_CHECKING:
 
     from github.Commit import Commit
     from github.Issue import Issue
+    from github.NamedUser import NamedUser
     from github.PaginatedList import PaginatedList
     from github.PullRequest import PullRequest
     from github.Repository import Repository
@@ -68,6 +75,7 @@ class ChangeLog:
         self.filtered_repo_issues: list[Issue]
         self.unreleased: list[PullRequest]
         self.unreleased_issues: list[Issue]
+        self.contributors: list[NamedUser]
 
     def run(self) -> None:
         """Run the changelog.
@@ -90,6 +98,53 @@ class ChangeLog:
         # actually generate the changelog file from all the data we have
         # collected.
         self.generate_changelog()
+
+        # update the CONTRIBUTORS.md file
+        self.contributors = self.get_contributors()
+        self.update_contributors()
+
+    def get_contributors(self) -> list[NamedUser]:
+        """This will get all the contributors to the repo.
+
+        It will return a list of NamedUser objects, getting these from the list
+        of PRs and Issues, removing any duplicates
+        """
+        user_list: list[NamedUser] = []
+        print("  [green]->[/green] Getting Contributors ... ", end="")
+        for pr in self.repo_prs:
+            if pr.user not in user_list:
+                user_list.append(pr.user)
+        print(self.done_str)
+
+        print("  [green]->[/green] Sorting Contributors ... ", end="")
+        user_list.sort(key=lambda x: x.name if x.name else x.login)
+        print(self.done_str)
+
+        return user_list
+
+    def update_contributors(self) -> None:
+        """Update the CONTRIBUTORS.md file."""
+        print("  [green]->[/green] Updating CONTRIBUTORS.md ... ", end="")
+        with Path(Path.cwd() / CONTRIBUTORS_FILE).open(
+            mode="w",
+            encoding="utf-8",
+        ) as f:
+            f.write("# Contributors\n\n")
+            f.write(
+                "The following people have contributed to the development "
+                f"of {self.repo_data.name}:\n\n"
+            )
+            for contributor in self.contributors:
+                if contributor.login in IGNORED_CONTRIBUTORS:
+                    continue
+                name = (
+                    contributor.name if contributor.name else contributor.login
+                ).capitalize()
+                f.write(
+                    f"- {name} "
+                    f"([@{contributor.login}]({contributor.html_url}))\n",
+                )
+        print(self.done_str, "\n")
 
     def generate_changelog(self) -> None:
         """Generate a markdown changelog using the data we have gererated."""

--- a/github_changelog_md/constants.py
+++ b/github_changelog_md/constants.py
@@ -37,6 +37,12 @@ IGNORED_LABELS: list[str] = [
     "wontfix",
 ]
 
+IGNORED_CONTRIBUTORS: list[str] = [
+    "dependabot[bot]",
+    "pre-commit-ci[bot]",
+    "dependabot-preview[bot]",
+]
 
-CONFIG_FILE = ".changelog_generator.toml"
-OUTPUT_FILE = "CHANGELOG.md"
+CONFIG_FILE: str = ".changelog_generator.toml"
+OUTPUT_FILE: str = "CHANGELOG.md"
+CONTRIBUTORS_FILE: str = "CONTRIBUTORS.md"

--- a/github_changelog_md/main.py
+++ b/github_changelog_md/main.py
@@ -52,6 +52,11 @@ def main(
         help="Show unreleased changes in the Changelog.",
         show_default=True,
     ),
+    contrib: Optional[bool] = typer.Option(
+        default=False,
+        help="Update CONTRIBUTORS.md.",
+        show_default=True,
+    ),
     depends: Optional[bool] = typer.Option(
         default=True,
         help="Show dependency updates in the Changelog.",
@@ -98,6 +103,7 @@ def main(
         "show_unreleased": unreleased,
         "show_depends": depends,
         "output_file": output,
+        "contributors": contrib,
     }
 
     cl = ChangeLog(repo, options)

--- a/tests/test_changelog.py
+++ b/tests/test_changelog.py
@@ -197,6 +197,7 @@ class TestChangelog:
                 "user_name": "user",
                 "next_release": None,
                 "show_unreleased": True,
+                "contributors": False,
             },
         )
         changelog.get_repo_data = MagicMock(return_value=mock_repo_data)

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -26,6 +26,7 @@ default_options = {
     "show_unreleased": True,
     "show_depends": True,
     "output_file": "CHANGELOG.md",
+    "contributors": False,
 }
 
 


### PR DESCRIPTION
Note that on large repos, this takes a loooong time, so only do it before a release or do it once and then update manually.

I will look at ways to optimize this in the future.