### PR TITLE
implement custom sections in a release

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -33,6 +33,7 @@
   "git.enableCommitSigning": true,
   "html.format.indentHandlebars": true,
   "html.format.templating": true,
+  "markdownlint.ignore": ["CHANGELOG.md"],
   "material-icon-theme.languages.associations": {
     "jinja-html": "django"
   },

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 **Enhancements**
 
+- Skip release(s) through CLI option or in settings ([#88](https://github.com/seapagan/github-changelog-md/pull/88)) by [seapagan](https://github.com/seapagan)
 - Implement getting settings from the config file ([#87](https://github.com/seapagan/github-changelog-md/pull/87)) by [seapagan](https://github.com/seapagan)
 - Implement quiet mode ([#86](https://github.com/seapagan/github-changelog-md/pull/86)) by [seapagan](https://github.com/seapagan)
 - Implement creating a CONTRIBUTORS file ([#85](https://github.com/seapagan/github-changelog-md/pull/85)) by [seapagan](https://github.com/seapagan)

--- a/TODO.md
+++ b/TODO.md
@@ -12,7 +12,9 @@ in the next release.
 
 ## Features to Add
 
-- :fire: Allow custom sections in the output, set by `label` or a regex.
+- :rocket: Allow custom sections in the output, set by `label`.
+- allow the `extend_sections` option to use a regex on the PR title in addition
+  to just matching on the label.
 - Allow custom ordering of sections.
 - Allow custom output formats (e.g. HTML, Markdown, PDF, LaTeX, etc.).
 - Ability to only update changes and leave the rest of the file untouched (ie do
@@ -27,7 +29,7 @@ in the next release.
   week, last month, etc.)
 - Add support for generating changelogs for specific contributors, authors or
   teams.
-- :fire: add ability to create a new release on GitHub with the latest changelog
+- add ability to create a new release on GitHub with the latest changelog
   text as the body.
 - add some form of text or even block to the oldest release that says something
   like "First release" or "Initial release" or "Initial commit" or something
@@ -52,7 +54,7 @@ in the next release.
   file or similar. Can use comment markers in the file to indicate where to add
   the names. Provide a default file with the comment markers in it or just
   document the process?
-- :fire: If there is no local config file, check for a global config file in the
+- If there is no local config file, check for a global config file in the
   user's home directory. This would allow a user to set their GitHub PAT once
   and use it for all projects.
 - dump markdown code for a specific release to the terminal, so it can be copy /
@@ -75,6 +77,19 @@ in the next release.
 - option to start at a specific release, ignoring all previous releases.
 - :rocket: add a default list of ignored labels, eg 'duplicate', 'invalid',
   'question', 'wontfix', etc.
+- add `extend_ignored_labels` option to add to the default list of ignored
+  labels.
+- add `ignored_labels` option to override the default list of ignored labels.
+- add `allowed_labels` option to specify which of the default ignored labels you
+  want to include in the changelog.
+- once the common config file functionality is implemented, add the ability to
+  read the config from a `pyproject.toml` file if it exists in the current
+  directory. This will allow one less config file. Note that the PAT will still
+  need to be set manually in the local or global config file.
+- :fire: add option to specify the GitHub PAT from the command line, eg `--token
+  <PAT>`. This will override any PAT set in the config file. **Note that this
+  can be a security risk if the PAT is visible in the command history, so it
+  should be used with caution.**
 
 ## Improve existing functionality
 

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -1,2 +1,3 @@
 <!-- pyml disable-next-line first-line-heading -->
+<!-- markdownlint-disable MD041 -->
 --8<-- "CHANGELOG.md"

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -1,2 +1,3 @@
 <!-- pyml disable-next-line first-line-heading -->
+<!-- markdownlint-disable MD041 -->
 --8<-- "CONTRIBUTING.md"

--- a/docs/index.md
+++ b/docs/index.md
@@ -13,7 +13,7 @@ a section for **unreleased** PRs (those since the last release) at the top. It
 will also include a list of all Issues closed for each release.
 
 The PRs and issues are grouped by type (bug, enhancement, etc.) and sorted by
-latest to oldest in this release.
+latest to oldest in this release. You can add a custom section to the list too.
 
 There is an option to tag all the Unreleased PRs (ie those closed after the
 previous release) with an upcoming release number to ease the process of
@@ -24,7 +24,7 @@ While the project is written in Python, it is **NOT** limited to just generating
 a changelog for Python projects. It will work with **any Github repository** and
 therefore **any coding language**. In this case a
 [global](installation.md#globally) installation is recommended. Most linux-based
-systems will already have Python installed, but if not it is easy to install.
+systems will already have Python installed, but if not, it is easy to install.
 Windows and the latest releases of MacOS will need Python to be installed, see
 the [Python documentation](https://www.python.org/downloads/){:target="_blank"}
 for details.

--- a/docs/license.md
+++ b/docs/license.md
@@ -1,2 +1,3 @@
 <!-- pyml disable-next-line first-line-heading -->
+<!-- markdownlint-disable MD041 -->
 --8<-- "LICENSE.txt"

--- a/docs/todo_list.md
+++ b/docs/todo_list.md
@@ -1,2 +1,3 @@
 <!-- pyml disable-next-line first-line-heading -->
+<!-- markdownlint-disable MD041 -->
 --8<-- "TODO.md"

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -66,16 +66,51 @@ You can tag each of your PRs with any of these labels to group them in the
 changelog - If you are using `Dependabot`, by default it will add the
 `dependencies` label.
 
-Labels are case-insensitive, so `bug` or `BUG` will both
-match "Bug Fixes". The above order is also the order that the sections will
-appear in the changelog.
+Labels are **case-insensitive**, so `bug` or `BUG` will both match "Bug Fixes".
+The above order is also the order that the sections will appear in the
+changelog, again this order will be customizable in future versions.
+
+### Custom Sections
+
+You can also **add** your own custom section headers, by adding a `label` to
+your PRs that matches the `label` you specify in the config file. For example,
+if you add the following to your config file:
+
+```toml
+extend_sections = [
+  { title = "Automatic Testing", label = "testing" },
+  { title = "Security", label = "security" },
+]
+```
+
+Now, any PRs that have the `testing` label will be added to a section called
+`Automatic Testing`, and `security` will be in `Security`. At the moment these
+are added at the end of the release section, future versions will allow you to
+specify the order of the sections. There is no limit to the number of custom
+sections you can add.
+
+The format for this option is an [array of
+tables](https://toml.io/en/v1.0.0#array-of-tables){:target="_blank}, with each
+table containing a `title` and a `label`. The above example uses an `inline TOML
+array of tables` but the normal fomat will also work:
+
+```toml
+[[extend_sections]]
+title = "Automatic Testing"
+label = "testing"
+
+[[extend_sections]]
+title = "Security"
+label = "security"
+```
+
+Inline arrays as in the first example are just a bit easier to read.
 
 !!! tip
 
-    For the moment, limit your PRs to a single label, as the tool will only
-    include the PR in the first section it finds a label for. This will be
-    improved in future versions, and you will also be able to customize the
-    section headers and add your own. I also plan to add the ability to use
+    For the moment, limit your PRs to a single label, as otherwise the tool will
+    include the PR in each section it finds a label for. This will be improved
+    in future versions. I also plan to add the ability to use
     multiple labels for the same section, eg `enhancement` and `enhancements`
 
 ## Ignored Labels
@@ -92,7 +127,10 @@ These are ignored for both PRs and Issues.
 
 !!! tip
 
-    This list of ignored labels will be customizable in future versions.
+    This list of ignored labels will be customizable in future versions using a
+    combination of `extend_ignored_labels` and `ignored_labels`. There will
+    probably also be an `allowed_labels` option, so you can specify which of the
+    default ignored labels you want to include in the changelog.
 
 ## Configuration File
 
@@ -105,7 +143,8 @@ setting. The other settings are optional, and can be set on the command line
 config file will be overridden by the command line options.
 
 The config file is in [TOML](https://toml.io/en/){:target="_blank"} format, and
-can be edited manually.
+can be edited manually. All settings are under the `[changelog_generator]`
+section, and any other sections will be ignored.
 
 Current available options are:
 
@@ -118,6 +157,7 @@ Current available options are:
 | `contrib`         | Create CONTRIBUTORS.md file        | `False`     |
 | `quiet`           | Suppress output                    | `False`     |
 | `skip_releases`   | List of releases to skip           | `[]`        |
+| `extend_sections` | Add custom sections                | `[]`        |
 | _`schema_version`_| _Configuration schema version_     | _`1`_       |
 
 !!! tip "Config file schema version"
@@ -142,13 +182,16 @@ quiet = false
 depends = true
 contrib = false
 skip_releases = ["1.2.3", "1.2.4"]
+extend_sections = [
+  { title = "Automatic Testing", label = "testing" },
+]
 ```
 
 As mentioned above, the only required setting is the `github_pat` setting. The
 other settings can be left out, and the tool will use the default values (or the
 values specified on the command line).
 
-## Advanced Usage
+## Command Line Options
 
 There are some options you can use to customize the output of the tool.
 

--- a/github_changelog_md/config/settings.py
+++ b/github_changelog_md/config/settings.py
@@ -8,7 +8,11 @@ from rich.prompt import Prompt
 from simple_toml_settings import TOMLSettings
 from simple_toml_settings.exceptions import SettingsNotFoundError
 
-from github_changelog_md.constants import CONFIG_FILE, OUTPUT_FILE, ExitErrors
+from github_changelog_md.constants import (
+    CONFIG_FILE,
+    OUTPUT_FILE,
+    ExitErrors,
+)
 
 
 class Settings(TOMLSettings):
@@ -21,6 +25,7 @@ class Settings(TOMLSettings):
     contrib: bool = False
     quiet: bool = False
     skip_releases: ClassVar[list[str]] = []
+    extend_sections: ClassVar[list[dict[str, str]]] = []
 
 
 def get_settings_object() -> Settings:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -100,6 +100,7 @@ changelog.help = "Generate the CHANGELOG.md file"
 [tool.pymarkdown]
 plugins.md014.enabled = false
 plugins.md036.enabled = false
+plugins.md046.enabled = false
 
 [tool.pytest.ini_options]
 addopts = ["--cov", "--cov-report", "term-missing", "--cov-report", "html"]


### PR DESCRIPTION
Allow the user to add custom sections, linked to a specific label. These are defined in the configuration file only