### PR TITLE
bug - missing pat causes crash

### DIFF
--- a/github_changelog_md/changelog/changelog.py
+++ b/github_changelog_md/changelog/changelog.py
@@ -62,8 +62,15 @@ class ChangeLog:
         options: dict[str, Any],
     ) -> None:
         """Initialize the class."""
-        self.auth = Auth.Token(get_settings().github_pat)
-        self.git = Github(auth=self.auth)
+        try:
+            self.auth = Auth.Token(get_settings().github_pat)
+            self.git = Github(auth=self.auth)
+        except AttributeError as exc:
+            print(
+                "\n[red]  X  Error: No GitHub PAT found in settings file\n",
+                file=sys.stderr,
+            )
+            raise typer.Exit(ExitErrors.NO_PAT) from exc
 
         self.repo_name: str = repo_name
         self.user: str | None = options["user_name"]

--- a/github_changelog_md/constants.py
+++ b/github_changelog_md/constants.py
@@ -16,6 +16,7 @@ class ExitErrors(IntEnum):
     USER_ABORT = 3
     OS_ERROR = 4
     INVALID_ACTION = 5
+    NO_PAT = 6
 
 
 # label names should be lowercase


### PR DESCRIPTION
If a config file exists without a `github_pat` key, the program will crash. This fixes that and gives a graceful exit instead.