### PR TITLE
change default location of custom sections and allow custom location

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -104,10 +104,13 @@ in the next release.
   the same.
 - allow multiple labels to be used for the same section, eg 'enhancement'
   and 'enhancements' both map to the 'Enhancements' section.
-- :fire: for custom sections, put it before the 'Depencency Updates' section
+- :rocket: for custom sections, put it before the 'Depencency Updates' section
   instead of at the end. The Deps section is usualy last, so this will allow
   custom sections to be placed before it. Don't rely on deps being last though,
   since this may change, use it's index to find it then insert before.
+- :rocket: allow the user to specfiy the index of the custom section, so it can
+  be placed anywhere in the output.
+- hide the closed issues section on demand.
 
 ## Known Issues
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -13,7 +13,7 @@ a section for **unreleased** PRs (those since the last release) at the top. It
 will also include a list of all Issues closed for each release.
 
 The PRs and issues are grouped by type (bug, enhancement, etc.) and sorted by
-latest to oldest in this release. You can add a custom section to the list too.
+latest to oldest in this release. You can add custom sections to the list too.
 
 There is an option to tag all the Unreleased PRs (ie those closed after the
 previous release) with an upcoming release number to ease the process of

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -84,10 +84,27 @@ extend_sections = [
 ```
 
 Now, any PRs that have the `testing` label will be added to a section called
-`Automatic Testing`, and `security` will be in `Security`. At the moment these
-are added at the end of the release section, future versions will allow you to
-specify the order of the sections. There is no limit to the number of custom
-sections you can add.
+`Automatic Testing`, and `security` labels will be in `Security`. By default
+these are inserted just before the `Dependency Updates` section, but you can
+specify the `extend_sections_index` value in the config file to change the index
+at which they they are inserted.
+
+!!! warning "Be Aware of the Index!"
+
+    The value of `extend_sections_index` is the **index** of the section, not
+    the **position**. The first section has an index of `0`, the second has an
+    index of `1`, etc. So if you want your custom sections to appear after the
+    `Enhancements` section, you would set the `extend_sections_index` to `3`
+    (the index of the next section, `Bug Fixes`)
+
+    **HOWEVER** this index is the index of the **default** sections (listed
+    above) that you want to insert BEFORE, even if those sections are not
+    displayed. So an index of 0 to 2 could still be before the `Enhancements`
+    section, if the `Breaking Changes` or `Merged Pull Requests` sections are
+    not displayed. Play with the value to get the desired result :grin:.
+
+    Finally, the `Closed Issues` section is separate and always displayed first
+    regardless of the `extend_sections_index` value.
 
 The format for this option is an [array of
 tables](https://toml.io/en/v1.0.0#array-of-tables){:target="_blank}, with each
@@ -149,18 +166,19 @@ section, and any other sections will be ignored.
 
 Current available options are:
 
-| **Setting**       | **Description**                    | **Default** |
-|-------------------|------------------------------------|-------------|
-| **`github_pat`**  | Your GitHub PAT                    |             |
-| `output_file`     | Output filename                    |CHANGELOG.md |
-| `unreleased`      | Include unreleased section         | `True`      |
-| `depends`         | Include dependency updates section | `True`      |
-| `contrib`         | Create CONTRIBUTORS.md file        | `False`     |
-| `quiet`           | Suppress output                    | `False`     |
-| `skip_releases`   | List of releases to skip           | `[]`        |
-| `extend_sections` | Add custom sections                | `[]`        |
-| `date_format`     | Date format for release dates      | `%Y-%m-%d`  |
-| _`schema_version`_| _Configuration schema version_     | _`1`_       |
+| **Setting**             | **Description**                    | **Default** |
+|-------------------------|------------------------------------|-------------|
+| **`github_pat`**        | Your GitHub PAT                    |             |
+| `output_file`           | Output filename                    |CHANGELOG.md |
+| `unreleased`            | Include unreleased section         | `True`      |
+| `depends`               | Include dependency updates section | `True`      |
+| `contrib`               | Create CONTRIBUTORS.md file        | `False`     |
+| `quiet`                 | Suppress output                    | `False`     |
+| `skip_releases`         | List of releases to skip           | `[]`        |
+| `extend_sections`       | Add custom sections                | `[]`        |
+| `extend_sections_index` | Index to insert custom sections    | dynamic[^1] |
+| `date_format`           | Date format for release dates      | `%Y-%m-%d`  |
+| _`schema_version`_      | _Configuration schema version_     | _`1`_       |
 
 !!! tip "Config file schema version"
 
@@ -187,6 +205,7 @@ skip_releases = ["1.2.3", "1.2.4"]
 extend_sections = [
   { title = "Automatic Testing", label = "testing" },
 ]
+extend_sections_index = 2
 date_format = "%d %B %Y"
 ```
 
@@ -296,3 +315,9 @@ excluded from the changelog. This is case-insensitive, so `[No Changelog]` or
 
 See the [Todo List](todo_list.md) for planned features. There are quite a few
 more options and customizations to come.
+
+[^1]:
+    The default setting is to insert your custom sections just before the
+    `Dependency Updates` section, but you can change this by setting the
+    `extend_sections_index` value. See the [Custom Sections](#custom-sections)
+    section for more details.

--- a/github_changelog_md/changelog/changelog.py
+++ b/github_changelog_md/changelog/changelog.py
@@ -23,9 +23,11 @@ from github_changelog_md.constants import (
     IGNORED_LABELS,
     SECTIONS,
     ExitErrors,
+    SectionHeadings,
 )
 from github_changelog_md.helpers import (
     cap_first_letter,
+    get_index_of_tuple,
     get_section_name,
     header,
 )
@@ -101,11 +103,7 @@ class ChangeLog:
 
         header()
 
-        extend_sections = [
-            (section["title"], section["label"])
-            for section in self.settings.extend_sections
-        ]
-        self.sections = SECTIONS + extend_sections
+        self.sections: list[SectionHeadings] = self.extend_sections()
 
         self.repo_data = self.get_repo_data()
         self.repo_releases = self.get_repo_releases()
@@ -130,6 +128,15 @@ class ChangeLog:
         if self.options["quiet"]:
             sys.stdout = orig_stdout
             out.close()
+
+    def extend_sections(self) -> list[SectionHeadings]:
+        """Extend the default sections with any user defined ones."""
+        extend_sections = [
+            (section["title"], section["label"])
+            for section in self.settings.extend_sections
+        ]
+        deps_index = get_index_of_tuple(SECTIONS, 1, "dependencies")
+        return SECTIONS[:deps_index] + extend_sections + SECTIONS[deps_index:]
 
     def get_contributors(self) -> list[NamedUser]:
         """This will get all the contributors to the repo.

--- a/github_changelog_md/changelog/changelog.py
+++ b/github_changelog_md/changelog/changelog.py
@@ -135,8 +135,16 @@ class ChangeLog:
             (section["title"], section["label"])
             for section in self.settings.extend_sections
         ]
-        deps_index = get_index_of_tuple(SECTIONS, 1, "dependencies")
-        return SECTIONS[:deps_index] + extend_sections + SECTIONS[deps_index:]
+
+        insert_index = (
+            self.settings.extend_sections_index
+            if self.settings.extend_sections_index
+            else get_index_of_tuple(SECTIONS, 1, "dependencies")
+        )
+
+        return (
+            SECTIONS[:insert_index] + extend_sections + SECTIONS[insert_index:]
+        )
 
     def get_contributors(self) -> list[NamedUser]:
         """This will get all the contributors to the repo.

--- a/github_changelog_md/config/settings.py
+++ b/github_changelog_md/config/settings.py
@@ -1,7 +1,7 @@
 """Handle the settings for the project."""
 import sys
 from pathlib import Path
-from typing import ClassVar
+from typing import ClassVar, Optional
 
 from rich import print  # pylint: disable=redefined-builtin
 from rich.prompt import Prompt
@@ -26,6 +26,7 @@ class Settings(TOMLSettings):
     quiet: bool = False
     skip_releases: ClassVar[list[str]] = []
     extend_sections: ClassVar[list[dict[str, str]]] = []
+    extend_sections_index: Optional[int] = None
     date_format: str = "%Y-%m-%d"
 
 

--- a/github_changelog_md/helpers.py
+++ b/github_changelog_md/helpers.py
@@ -8,7 +8,7 @@ from pathlib import Path
 import rtoml
 from rich import print  # pylint: disable=redefined-builtin
 
-from github_changelog_md.constants import SECTIONS, ExitErrors
+from github_changelog_md.constants import SECTIONS, ExitErrors, SectionHeadings
 
 
 def get_toml_path() -> Path:
@@ -89,3 +89,16 @@ def get_section_name(label: str | None) -> str | None:
         if section[1] == label:
             return section[0]
     return None
+
+
+def get_index_of_tuple(
+    tuple_list: list[SectionHeadings], index: int, value: str
+) -> int:
+    """Return the index of a tuple in a list."""
+    for pos, t in enumerate(tuple_list):
+        if t[index] == value:
+            return pos
+
+    # Matches behavior of list.index
+    error_msg = "list.index(x): x not in list"
+    raise ValueError(error_msg)

--- a/github_changelog_md/helpers.py
+++ b/github_changelog_md/helpers.py
@@ -99,6 +99,5 @@ def get_index_of_tuple(
         if t[index] == value:
             return pos
 
-    # Matches behavior of list.index
-    error_msg = "list.index(x): x not in list"
+    error_msg = f"'{value}' is not in the supplied list of Tuples"
     raise ValueError(error_msg)

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -39,6 +39,7 @@ repo_name: github-changelog-md
 # edit these MARKDOWN extensions to your liking
 markdown_extensions:
   - admonition
+  - footnotes
   - pymdownx.snippets
   - pymdownx.superfences
   - pymdownx.highlight:


### PR DESCRIPTION
They are put before the 'dependency' section now instead of the end