### PR TITLE
implement '--no-issues' flag to hide closed issues from the generated changelog

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -26,8 +26,8 @@ in the next release.
   week, last month, etc.)
 - Add support for generating changelogs for specific contributors, authors or
   teams.
-- :fire: add ability to create a new release on GitHub with the latest changelog
-  text as the body.
+- :fire: add ability to create a new draft release on GitHub with the latest
+  changelog text as the body.
 - add some form of text or even block to the oldest release that says something
   like "First release" or "Initial release" or "Initial commit" or something
   (configurable) to indicate that this is the first release and nothing to
@@ -35,22 +35,20 @@ in the next release.
 - add ability to place a section between releases with custom markdown, eg to
   explain changes in the version numbering scheme or other important
   information.
-- option to change PR/Issue/Commit links to use the GitHub autolink syntax
-  instead of explicitly linking to the GitHub page.
-- Allow to add a text block to the 'Breaking Changes' section. Can be added to
-  the config file, or more usefully to a dedicated file linking releases to a
-  text block.
-- Use the above secondary config file for every release to add a custom text
-  block to the release?
-- Add an option to add a custom text block to the top of the changelog, eg to
-  explain the version numbering scheme or other important information.
+- :fire: option to change PR/Issue/Commit links to use the GitHub autolink
+  syntax instead of explicitly linking to the GitHub page.
+- Allow to add a text block to the 'Breaking Changes' section. Should be added
+  to the config file.
+- Add config option to add a custom text block to specfic releases.
+- Add an option to add a custom text block to the top of the changelog.
 - investigate adding caching of the GitHub API calls to speed up the process.
 - for the `--contrib` option, allow to use an existing file with comment markers
   in the file to indicate where to add the names. Provide a default file with
   the comment markers in it or just document the process?
-- :fire: If there is no local config file, check for a global config file in the
+- If there is no local config file, check for a global config file in the
   user's home directory. This would allow a user to set their GitHub PAT once
-  and use it for all projects.
+  and use it for all projects. \[`Probably needs to be done in the settings
+  package`\]
 - dump markdown code for a specific release to the terminal, so it can be copy /
   pasted into other docs.
 - option to hide certain headers, or remove all headers and just have a list of
@@ -74,10 +72,10 @@ in the next release.
 - add option to specify the GitHub PAT from the command line, eg `--token
   <PAT>`. This will override any PAT set in the config file. **Note that this
   can be a security risk if the PAT is visible in the command history, so it
-  should be used with caution.** `This needs the settings logic to be refactored
-  first, the way it is done at the moment it will still ask for the PAT if it is
-  not set in the config file, even if it is set on the command line, since this
-  is a side-effect of importing the settings library.`
+  should be used with caution.** \[`This needs the settings logic to be
+  refactored first, the way it is done at the moment it will still ask for the
+  PAT if it is not set in the config file, even if it is set on the command
+  line, since this is a side-effect of importing the settings library.`\]
 
 ## Improve existing functionality
 
@@ -87,18 +85,23 @@ in the next release.
 - add link targets to the release headers so they can be linked to directly.
 - allow multiple labels to be used for the same section, eg 'enhancement'
   and 'enhancements' both map to the 'Enhancements' section.
-- :fire: hide the closed issues section on demand.
+- :rocket: hide the closed issues section on demand.
 - :fire: allow to hide PR's from the output by their number.
 - :fire: if the tool is run in a local repo, use that for the `--contrib` functionality
   instead of the GitHub API. This should be an order of magnitude faster. Have
   an opt-out option to use the GitHub API instead.
+- :fire: don't dump all possible setting options to the config file when we
+  create it. The only time we should write to the config is when setting the PAT
+  for a missing file. The settings package `save()` always writes all settings
+  to the file, so we need to just manually create the file the first time.
 
 ## Known Issues
 
 - some version numbers in PRs (especially dependabot) get mis-identified as
   emojis in the output, especially if the version number contains `<3` which
-  gives <3. This is very obvious for 'pip' version numbers. We need to escape
-  this particular pattern in the PR title.
+  gives :heart: in certain viewers (**though this does NOT happen in GitHub or
+  MkDocs at least**). This is very obvious for 'pip' version numbers. It's not a
+  priority to fix this for it's intended usage, but just for completeness.
 - The table styling under mobile looks a bit squashed due to setting the width
   to 100% for better desktop display. Need to add a media query to set the width
   better for mobile.

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -164,6 +164,12 @@ The config file is in [TOML](https://toml.io/en/){:target="_blank"} format, and
 can be edited manually. All settings are under the `[changelog_generator]`
 section, and any other sections will be ignored.
 
+!!! danger "Add to .gitignore"
+
+    As mentioned in the [Installation](installation.md) section, the config file
+    contains your GitHub PAT, so you should **NOT** commit this file to your
+    repository. Add it to your `.gitignore` file to prevent it being committed.
+
 Current available options are:
 
 | **Setting**             | **Description**                    | **Default** |
@@ -175,8 +181,9 @@ Current available options are:
 | `contrib`               | Create CONTRIBUTORS.md file        | `False`     |
 | `quiet`                 | Suppress output                    | `False`     |
 | `skip_releases`         | List of releases to skip           | `[]`        |
-| `extend_sections`       | Add custom sections                | `[]`        |
-| `extend_sections_index` | Index to insert custom sections    | dynamic[^1] |
+| `show_issues`           | Show closed issues                 | `True`      |
+| `extend_sections`       | A list of custom sections          | `[]`        |
+| `extend_sections_index` | Index to insert custom sections    | dynamic [^1]|
 | `date_format`           | Date format for release dates      | `%Y-%m-%d`  |
 | _`schema_version`_      | _Configuration schema version_     | _`1`_       |
 
@@ -193,9 +200,8 @@ Current available options are:
 
 ### Example Configuration File
 
-```toml
-[changelog_generator]
-github_pat = "123456"
+```toml hl_lines="1" title="changelog_generator.toml"
+github_pat = "1234567890" # (1)!
 schema_version = "1"
 unreleased = true
 quiet = false
@@ -206,8 +212,12 @@ extend_sections = [
   { title = "Automatic Testing", label = "testing" },
 ]
 extend_sections_index = 2
-date_format = "%d %B %Y"
+date_format = "%d %B %Y" # (2)!
 ```
+
+1. This is the only required setting, the others are optional.
+2. This setting uses the `strftime` format, see the block below for more
+   details.
 
 As mentioned above, the only required setting is the `github_pat` setting. The
 other settings can be left out, and the tool will use the default values (or the
@@ -241,6 +251,11 @@ can specify a different filename using the `--output` or `-o` option.
 $ github-changelog-md --output HISTORY.md
 ```
 
+!!! tip ""
+
+    :sparkles: Equivalent to the `output_file` setting in the config file.
+---
+
 ### `--next-release` / `-n`
 
 This option allows you to specify the name of the next release. By default, any
@@ -255,11 +270,21 @@ Useful to prep for a release before it is actually released.
 $ github-changelog-md --next-release 1.2.3
 ```
 
+!!! tip ""
+
+    :sparkles: There is no equivalent setting in the config file.
+---
+
 ### `--unreleased` / `--no-unreleased`
 
 Choose whether to include the `Unreleased` section in the changelog. By default
 the `Unreleased` section is included (`--unreleased`), but you can use the
 `--no-unreleased` option to exclude it
+
+!!! tip ""
+
+    :sparkles: Equivalent to the `unreleased` setting in the config file.
+---
 
 ### `--depends` / `--no-depends`
 
@@ -267,6 +292,21 @@ Choose whether to include the `Dependency Updates` section in the changelog. By
 default this will be shown (`--depends`), but you can use the `--no-depends` to
 hide them. Some releases have a lot of dependency updates, so this can be useful
 to keep the changelog more readable.
+
+!!! tip ""
+
+    :sparkles: Equivalent to the `depends` setting in the config file.
+---
+
+### `--issues` / `--no-issues`
+
+Hide the `Closed Issues` section. By default this section is shown, but you can
+use the `--no-issues` option to hide it.
+
+!!! tip ""
+
+    :sparkles: Equivalent to the `show_issues` setting in the config file.
+---
 
 ### `--contrib` / `--no-contrib`
 
@@ -285,11 +325,21 @@ Choose whether to create the `CONTRIBUTORS.md` file. By default this will be
     In future versions I will add the ability to cache the contributors list,
     which should speed things up a lot
 
+!!! tip ""
+
+    :sparkles: Equivalent to the `contrib` setting in the config file.
+---
+
 ### `--quiet` / `-q`
 
 By default the tool will output some information about what it is doing, and
 some stats about the PRs and Issues it has found. You can use the `--quiet` or
 `-q` option to suppress this output.
+
+!!! tip ""
+
+    :sparkles: Equivalent to the `quiet` setting in the config file.
+---
 
 ### `--skip` / `-s`
 
@@ -303,6 +353,11 @@ $ github-changelog-md --skip 1.2.3 --skip 1.3-beta1
 
 The string specified here is the actual release **`tag`** for that release, not
 the release **`name`**.
+
+!!! tip ""
+
+    :sparkles: Equivalent to the `skip_releases` setting in the config file.
+---
 
 ## Hide PR from the Changelog
 

--- a/github_changelog_md/changelog/changelog.py
+++ b/github_changelog_md/changelog/changelog.py
@@ -317,7 +317,7 @@ class ChangeLog:
 
     def print_issues(self, f: TextIOWrapper, issue_list: list[Issue]) -> None:
         """Print all the closed issues for a given release."""
-        if len(issue_list) == 0:
+        if len(issue_list) == 0 or not self.options["show_issues"]:
             return
         f.write("**Closed Issues**\n\n")
         for issue in issue_list:

--- a/github_changelog_md/config/settings.py
+++ b/github_changelog_md/config/settings.py
@@ -28,6 +28,7 @@ class Settings(TOMLSettings):
     extend_sections: ClassVar[list[dict[str, str]]] = []
     extend_sections_index: Optional[int] = None
     date_format: str = "%Y-%m-%d"
+    show_issues: bool = True
 
 
 def get_settings_object() -> Settings:

--- a/github_changelog_md/main.py
+++ b/github_changelog_md/main.py
@@ -84,6 +84,11 @@ def main(
         help="Skip the suplied tag. Can be specified multiple times",
         show_default=False,
     ),
+    issues: Optional[bool] = typer.Option(
+        default=None,
+        help="Show CLOSED issues in the Changelog, defaults to True.",
+        show_default=False,
+    ),
 ) -> None:
     """Generate your CHANGELOG file Automatically.
 
@@ -126,6 +131,7 @@ def main(
         "contributors": settings.contrib if contrib is None else contrib,
         "quiet": settings.quiet if quiet is None else quiet,
         "skip_releases": settings.skip_releases if skip == [] else skip,
+        "show_issues": settings.show_issues if issues is None else issues,
     }
 
     changelog = ChangeLog(repo, options)

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -9,6 +9,8 @@ theme:
   features:
     - navigation.footer
     - navigation.expand
+    - content.code.copy
+    - content.code.annotate
   icon:
     logo: material/history
   favicon: images/favicon.ico
@@ -42,6 +44,7 @@ markdown_extensions:
   - footnotes
   - pymdownx.snippets
   - pymdownx.superfences
+  - md_in_html
   - pymdownx.highlight:
       linenums: false
       auto_title: false


### PR DESCRIPTION
Add the options `--issues` (default) and `--no-issues` to show / hide the **Closed Issues** section in the CHANGELOG