### PR TITLE
Don't add all settings to auto-generated config file

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -53,8 +53,10 @@ in the next release.
   pasted into other docs.
 - option to hide certain headers, or remove all headers and just have a list of
   PRs.
-- :fire: change the order of PRs in the output - current is newest first, but we
-  could have oldest first or alphabetical by title or something.
+- :fire: change the order of PRs and Issues in the output - current is newest
+  first, but we could have oldest first or alphabetical by title or something.
+  Add a setting `item_order` with options `newest_first` (default),
+  `oldest_first` and `alphabetical`.
 - Add settings to run this as a GitHub action, so it can be run automatically
   when a new release is created or a PR is merged. We should be able to use the
   `secrets.GITHUB_TOKEN` for this?
@@ -90,10 +92,13 @@ in the next release.
 - :fire: if the tool is run in a local repo, use that for the `--contrib` functionality
   instead of the GitHub API. This should be an order of magnitude faster. Have
   an opt-out option to use the GitHub API instead.
-- :fire: don't dump all possible setting options to the config file when we
+- :rocket: don't dump all possible setting options to the config file when we
   create it. The only time we should write to the config is when setting the PAT
   for a missing file. The settings package `save()` always writes all settings
   to the file, so we need to just manually create the file the first time.
+- update the format for custom sections to allow each section to have it's own
+  insertion index. This will be a breaking change in the config file format so
+  require a `schema_version` bump.
 
 ## Known Issues
 

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -215,8 +215,8 @@ extend_sections_index = 2
 date_format = "%d %B %Y" # (2)!
 ```
 
-1. This is the only required setting, the others are optional.
-2. This setting uses the `strftime` format, see the block below for more
+1. :bulb: This is the only required setting, the others are optional.
+2. :bulb: This setting uses the `strftime` format, see the block below for more
    details.
 
 As mentioned above, the only required setting is the `github_pat` setting. The

--- a/github_changelog_md/config/settings.py
+++ b/github_changelog_md/config/settings.py
@@ -73,8 +73,9 @@ def get_settings() -> Settings:
         try:
             with Path(CONFIG_FILE).open("w") as f:
                 f.write(f"[changelog_generator]\ngithub_pat = '{get_pat}'\n")
-            settings = get_settings_object()
-            settings.save()
+                f.flush()
+                settings = get_settings_object()
+                f.write(f"schema_version = '{settings.schema_version}'\n")
         except PermissionError:
             print(
                 "\n[red]Permission denied. Please run the command in a folder "

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -114,7 +114,7 @@ class TestSettings:
         """Test settings error if we dont have write permission."""
         monkeypatch.setattr(MOCK_PROMPT_ASK, lambda _: "1234")
         mocker.patch(
-            "simple_toml_settings.settings.TOMLSettings.save",
+            "pathlib.Path.open",
             side_effect=PermissionError,
         )
         with pytest.raises(SystemExit) as exc:


### PR DESCRIPTION
The default action of the `save()` method from the settings package is to save all the settings, even if they were not specified in the file originally. This is a bit messy, so we generate our own minimal config file the first time instead.

There is no reason for this tool ever to change the config file after it is first created.