### PR TITLE
allow sorting PRs and Issues within each section of a release

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -53,10 +53,8 @@ in the next release.
   pasted into other docs.
 - option to hide certain headers, or remove all headers and just have a list of
   PRs.
-- :fire: change the order of PRs and Issues in the output - current is newest
-  first, but we could have oldest first or alphabetical by title or something.
-  Add a setting `item_order` with options `newest_first` (default),
-  `oldest_first` and `alphabetical`.
+- :rocket: change the order of PRs and Issues in the output - option to sort by
+  `newest-first` (default), or `oldest-first`.
 - Add settings to run this as a GitHub action, so it can be run automatically
   when a new release is created or a PR is merged. We should be able to use the
   `secrets.GITHUB_TOKEN` for this?

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -172,20 +172,21 @@ section, and any other sections will be ignored.
 
 Current available options are:
 
-| **Setting**             | **Description**                    | **Default** |
-|-------------------------|------------------------------------|-------------|
-| **`github_pat`**        | Your GitHub PAT                    |             |
-| `output_file`           | Output filename                    |CHANGELOG.md |
-| `unreleased`            | Include unreleased section         | `True`      |
-| `depends`               | Include dependency updates section | `True`      |
-| `contrib`               | Create CONTRIBUTORS.md file        | `False`     |
-| `quiet`                 | Suppress output                    | `False`     |
-| `skip_releases`         | List of releases to skip           | `[]`        |
-| `show_issues`           | Show closed issues                 | `True`      |
-| `extend_sections`       | A list of custom sections          | `[]`        |
-| `extend_sections_index` | Index to insert custom sections    | dynamic [^1]|
-| `date_format`           | Date format for release dates      | `%Y-%m-%d`  |
-| _`schema_version`_      | _Configuration schema version_     | _`1`_       |
+| **Setting**             | **Description**                    | **Default**   |
+|-------------------------|------------------------------------|---------------|
+| **`github_pat`**        | Your GitHub PAT                    |               |
+| `output_file`           | Output filename                    |CHANGELOG.md   |
+| `unreleased`            | Include unreleased section         | `True`        |
+| `depends`               | Include dependency updates section | `True`        |
+| `contrib`               | Create CONTRIBUTORS.md file        | `False`       |
+| `quiet`                 | Suppress output                    | `False`       |
+| `skip_releases`         | List of releases to skip           | `[]`          |
+| `show_issues`           | Show closed issues                 | `True`        |
+| `extend_sections`       | A list of custom sections          | `[]`          |
+| `extend_sections_index` | Index to insert custom sections    | dynamic [^1]  |
+| `date_format`           | Date format for release dates      | `%Y-%m-%d`    |
+| `item_order`            | Order of PR/Issues in each section | `newest_first`|
+| _`schema_version`_      | _Configuration schema version_     | _`1`_         |
 
 !!! tip "Config file schema version"
 
@@ -213,6 +214,7 @@ extend_sections = [
 ]
 extend_sections_index = 2
 date_format = "%d %B %Y" # (2)!
+item_order = "oldest_first"
 ```
 
 1. :bulb: This is the only required setting, the others are optional.
@@ -358,6 +360,16 @@ the release **`name`**.
 
     :sparkles: Equivalent to the `skip_releases` setting in the config file.
 ---
+
+### `--item-order` / `-i`
+
+This option allows you to specify the order of the PRs and Issues in each
+section. By default the order is `newest_first`, but you can use the
+`--item-order` or `-i` option to change this to `oldest_first`.
+
+!!! tip ""
+
+    :sparkles: Equivalent to the `item_order` setting in the config file.
 
 ## Hide PR from the Changelog
 

--- a/github_changelog_md/changelog/changelog.py
+++ b/github_changelog_md/changelog/changelog.py
@@ -320,7 +320,7 @@ class ChangeLog:
         if len(issue_list) == 0 or not self.options["show_issues"]:
             return
         f.write("**Closed Issues**\n\n")
-        for issue in issue_list:
+        for issue in self.get_sorted_items(issue_list):
             if (
                 any(
                     label.name.lower() in IGNORED_LABELS
@@ -390,7 +390,8 @@ class ChangeLog:
                 continue
             if len(prs) > 0:
                 f.write(f"**{heading}**\n\n")
-                for pr in prs[::-1]:
+                # for pr in prs[::-1]:
+                for pr in self.get_sorted_items(prs):
                     if "[no changelog]" in pr.title.lower():
                         continue
                     escaped_title = cap_first_letter(
@@ -402,6 +403,15 @@ class ChangeLog:
                         f"by [{pr.user.login}]({pr.user.html_url})\n",
                     )
                 f.write("\n")
+
+    def get_sorted_items(self, items: list[Any]) -> list[Any]:
+        """Sort the PRs or Issues into the required order."""
+        if self.options["item_order"] == "newest-first":
+            return sorted(items, key=lambda x: x.number, reverse=True)
+        if self.options["item_order"] == "oldest-first":
+            return sorted(items, key=lambda x: x.number)
+        # any other value will be ignored and the default order will be used
+        return items
 
     def get_release_sections(
         self, pr_list: list[PullRequest]

--- a/github_changelog_md/config/settings.py
+++ b/github_changelog_md/config/settings.py
@@ -29,6 +29,7 @@ class Settings(TOMLSettings):
     extend_sections_index: Optional[int] = None
     date_format: str = "%Y-%m-%d"
     show_issues: bool = True
+    item_order: str = "newest-first"
 
 
 def get_settings_object() -> Settings:

--- a/github_changelog_md/main.py
+++ b/github_changelog_md/main.py
@@ -50,17 +50,23 @@ def main(
     ),
     unreleased: Optional[bool] = typer.Option(
         default=None,
-        help="Show unreleased changes in the Changelog, defaults to True.",
+        help=(
+            "Show unreleased changes in the Changelog, defaults to [bold]True"
+            "[/bold]."
+        ),
         show_default=False,
     ),
     contrib: Optional[bool] = typer.Option(
         default=None,
-        help="Update CONTRIBUTORS.md, defaults to False.",
+        help="Update the CONTRIBUTORS.md file, defaults to [bold]False[/bold].",
         show_default=False,
     ),
     depends: Optional[bool] = typer.Option(
         default=None,
-        help="Show dependency updates in the Changelog, defaults to True.",
+        help=(
+            "Show dependency updates in the Changelog, defaults to [bold]True"
+            "[/bold]."
+        ),
         show_default=False,
     ),
     output: Optional[str] = typer.Option(
@@ -86,16 +92,25 @@ def main(
     ),
     issues: Optional[bool] = typer.Option(
         default=None,
-        help="Show CLOSED issues in the Changelog, defaults to True.",
+        help=(
+            "Show CLOSED issues in the Changelog, defaults to [bold]True"
+            "[/bold]."
+        ),
+        show_default=False,
+    ),
+    item_order: Optional[str] = typer.Option(
+        None,
+        "--item-order",
+        "-i",
+        help=(
+            "Order of PRs and Issues in a release section. "
+            "Valid options are [bold]'newest-first'[/bold] or [bold]'oldest-"
+            "first'[/bold]. Defaults to [bold]'newest-first'[/bold]."
+        ),
         show_default=False,
     ),
 ) -> None:
-    """Generate your CHANGELOG file Automatically.
-
-    If you don't specify a repository name, the application will try to
-    get the repository name from the current directory (assuming it is a git
-    repository).
-    """
+    """Generate your CHANGELOG file Automatically from GitHub."""
     if version:
         print(
             "\n[green]Github Changelog Markdown - "
@@ -132,6 +147,7 @@ def main(
         "quiet": settings.quiet if quiet is None else quiet,
         "skip_releases": settings.skip_releases if skip == [] else skip,
         "show_issues": settings.show_issues if issues is None else issues,
+        "item_order": settings.item_order if item_order is None else item_order,
     }
 
     changelog = ChangeLog(repo, options)


### PR DESCRIPTION
Allow to sort the PRs and Issues within each section - either `newest_first` (default) or `oldest_first`.