### PR TITLE
Handle missing release body

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -26,7 +26,7 @@ in the next release.
   week, last month, etc.)
 - Add support for generating changelogs for specific contributors, authors or
   teams.
-- :fire: add ability to create a new draft release on GitHub with the latest
+- add ability to create a new draft release on GitHub with the latest
   changelog text as the body.
 - add some form of text or even block to the oldest release that says something
   like "First release" or "Initial release" or "Initial commit" or something
@@ -81,7 +81,7 @@ in the next release.
 
 ## Improve existing functionality
 
-- :fire: if there are no PR for a specific release then say something to that
+- :rocket: if there are no PR for a specific release then say something to that
   effect instead of just leaving the section empty. We already use the Release
   'body' for this, but if that is missing too we need to say something.
 - add link targets to the release headers so they can be linked to directly.

--- a/github_changelog_md/changelog/changelog.py
+++ b/github_changelog_md/changelog/changelog.py
@@ -313,15 +313,22 @@ class ChangeLog:
         own. The auto-generated release notes on GitHub will
         add a diff link to the release notes. We don't want that.
         """
-        body_lines = release.body.split("\n")
-        for i, line in enumerate(body_lines):
-            if f"{self.repo_data.html_url}/compare/" in line:
-                body_lines.pop(i)
-                break
-        body = "\n".join(body_lines)
-        if body[-2] != "\n":
-            body += "\n"
-        f.write(body)
+        if release.body:
+            body_lines = release.body.split("\n")
+            for i, line in enumerate(body_lines):
+                if f"{self.repo_data.html_url}/compare/" in line:
+                    body_lines.pop(i)
+                    break
+            body = "\n".join(body_lines)
+            if body.strip() and body[-2] != "\n":
+                body += "\n"
+            f.write(body)
+        else:
+            f.write(
+                "There were no merged pull requests or closed issues "
+                "for this release.\n\n"
+                "See the Full Changelog below for details.\n\n"
+            )
 
     def print_issues(
         self,


### PR DESCRIPTION
If a release has no Issues or PRs, and if the release body is also empty, add a generic comment to that release in the changelog.