### PR TITLE
make the list of ignored labels customizable

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -14,7 +14,7 @@ in the next release.
 
 - allow the `extend_sections` option to use a regex on the PR title in addition
   to just matching on the label.
-- :fire: Allow custom ordering of sections.
+- Allow custom ordering of sections.
 - Allow custom output formats (e.g. HTML, Markdown, PDF, LaTeX, etc.).
 - Ability to only update changes and leave the rest of the file untouched (ie do
   not re-generate previous releases, only new ones or the unreleased section).
@@ -53,11 +53,11 @@ in the next release.
   when a new release is created or a PR is merged. We should be able to use the
   `secrets.GITHUB_TOKEN` for this?
 - option to start at a specific release, ignoring all previous releases.
-- :fire: add `extend_ignored_labels` option to add to the default list of
+- :rocket: add `extend_ignored` option to add to the default list of
   ignored labels.
-- :fire: add `ignored_labels` option to override the default list of ignored
+- :rocket: add `ignored_labels` option to override the default list of ignored
   labels.
-- :fire: add `allowed_labels` option to specify which of the default ignored
+- :rocket: add `allowed_labels` option to specify which of the default ignored
   labels you want to include in the changelog.
 - once the common config file functionality is implemented, add the ability to
   read the config from a `pyproject.toml` file if it exists in the current

--- a/docs/index.md
+++ b/docs/index.md
@@ -6,8 +6,21 @@
 version](https://badge.fury.io/py/github-changelog-md.svg)](https://badge.fury.io/py/github-changelog-md)&nbsp;
 ![PyPI - License](https://img.shields.io/pypi/l/github-changelog-md)&nbsp;
 
-This project will generate a Markdown-formatted Changelog from a Github
-repository. It will detect all GitHub releases and generate a changelog based on
+Having a changelog is a great way to keep your users informed about changes to
+your project. It is also a great way to keep track of what you have done and
+when. However, it can be a pain to maintain, especially if you have a lot of
+changes. This tool aims to make it easy to generate a Markdown-formatted
+changelog from your project's Github repository.
+
+!!! warning "Important!"
+
+    You need to use the Github `Pull Request` and `Release` methodology for this
+    tool to work. If you don't, then this tool is not for you!
+
+    Until you have at least one GitHub Release, this tool will lump all the PRs
+    together under the `Unreleased` heading.
+
+It will detect all GitHub releases and generate a changelog based on
 the **merged** Pull Requests for each release along with a section for
 **unreleased** PRs (those merged since the last release) at the top. It will
 also include a list of all Issues closed for each release.
@@ -20,7 +33,7 @@ previous release) with an upcoming release number to ease the process of
 creating a new release by having the changelog already up to date, *or hide any
 unreleased PR's completely*.
 
-There is much more this app can do, see the [Usage](usage.md) page for more
+There is much more this app can do, see the [Usage](usage.md) page for full
 details.
 
 While the project is written in Python, it is **NOT** limited to just generating

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -10,7 +10,7 @@
     PRs.
 
 This tool is designed to be run from the root of a project, and will generate a
-`CHANGELOG.md` file in the current folder using the GitHub release and PR
+`CHANGELOG.md` file in the current folder using the GitHub Release and PR
 history. It can also create a `CONTRIBUTORS.md` file if you want it to.
 
 Note that this tool is designed to be run **after** you have merged your PRs,
@@ -180,8 +180,8 @@ you can use the inline array format or the verbose format as you prefer.
 
 ## Ignored Labels
 
-There are a few labels that are ignored by default, as they should not be
-included in the changelog. These are:
+There are a few labels that are ignored by default and will not be included in
+the changelog. These are:
 
 - `duplicate`
 - `invalid`
@@ -190,12 +190,63 @@ included in the changelog. These are:
 
 These are ignored for both PRs and Issues.
 
-!!! tip
+### Customizing Ignored Labels
 
-    This list of ignored labels will be customizable in future versions using a
-    combination of `extend_ignored_labels` and `ignored_labels`. There will
-    probably also be an `allowed_labels` option, so you can specify which of the
-    default ignored labels you want to include in the changelog.
+There are three ways to customize the ignored labels, all using settings in the
+config file.
+
+#### `ignored_labels`
+
+The `ignored_labels` setting is a definitive list of labels that should be
+ignored. This totally replaces the default list. For example, if you only want
+to ignore the `wontfix` label, but include every other label, you would add the
+following to your config file:
+
+```toml
+ignored_labels = ["wontfix"]
+```
+
+!!! danger ""
+
+    :sparkles: If this setting is present in your config file, the
+    `extend_ignored` and `allowed_labels` settings will be silently ignored.
+
+#### `extend_ignored`
+
+The `extend_ignored` setting is a list of labels to add to the default list. For
+example, if you don't want to list documentation changes in the changelog, you
+could add the following to your config file:
+
+```toml
+extend_ignored = ["documentation"]
+```
+
+!!! danger ""
+
+    :sparkles: This setting is ignored if you also have the `ignored_labels`
+    setting in your config file.
+
+#### `allowed_labels`
+
+Finally, the `allowed_labels` setting is a list of labels that should be
+included, even if they are in the default list. For example, if you want to
+include the `question` label in the changelog, you could add the following to
+your config file:
+
+```toml
+allowed_labels = ["question"]
+```
+
+!!! danger ""
+
+    :sparkles: This setting is ignored if you also have the `ignored_labels`
+    setting in your config file.
+
+!!! Tip "Tip"
+
+    You CAN combine the `extend_ignored` and `allowed_labels` settings if needed
+    , but it is probably easier to just use the `ignored_labels` setting
+    instead.
 
 ## Configuration File
 
@@ -235,6 +286,9 @@ Current available options are:
 | `date_format`           | Date format for release dates      | `%Y-%m-%d`    |
 | `item_order`            | Order of PR/Issues in each section | `newest_first`|
 | `ignore_items`          | List of PRs/Issues to ignore       | `[]`          |
+| `ignored_labels`        | List of labels to ignore           | See above     |
+| `extend_ignored`        | List of labels to add to ignored   | `[]`          |
+| `allowed_labels`        | List of labels to allow            | `[]`          |
 | _`schema_version`_      | _Configuration schema version_     | _`1`_         |
 
 !!! tip "Config file schema version"
@@ -267,6 +321,8 @@ rename_sections = [{ old = "Enhancements", new = "New Features" }]
 date_format = "%d %B %Y" # (2)!
 item_order = "oldest_first"
 ignore_items = [123, 456] # (3)!
+extend_ignored = ["testing"]
+allowed_labels = ["question"]
 ```
 
 1. :bulb: This is the only required setting, the others are optional.

--- a/github_changelog_md/config/settings.py
+++ b/github_changelog_md/config/settings.py
@@ -32,6 +32,7 @@ class Settings(TOMLSettings):
     show_issues: bool = True
     item_order: str = "newest-first"
     ignore_items: ClassVar[list[int]] = []
+    extend_ignored: ClassVar[list[str]] = []
 
 
 def get_settings_object() -> Settings:

--- a/github_changelog_md/config/settings.py
+++ b/github_changelog_md/config/settings.py
@@ -33,6 +33,8 @@ class Settings(TOMLSettings):
     item_order: str = "newest-first"
     ignore_items: ClassVar[list[int]] = []
     extend_ignored: ClassVar[list[str]] = []
+    ignored_labels: ClassVar[list[str]] = []
+    allowed_labels: ClassVar[list[str]] = []
 
 
 def get_settings_object() -> Settings:


### PR DESCRIPTION
Add some config file options to allow customization of the ignored labels list.

 - [x] Add `extend_ignored` to add items to the ignore list.
 - [x] Add `ignored_labels` to completely overwrite the ignore list.
 - [x] Add `allowed labels` to allow previously ignored labels

If `ignored_labels` is specified, the other two are silently ignored