### PR TITLE
Allow to only show `max_depends` number of dependency updates for each release

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -29,9 +29,9 @@ in the next release.
   like "First release" or "Initial release" or "Initial commit" or something
   (configurable) to indicate that this is the first release and nothing to
   compare to. Optionally hide all PR, Issue and commit links in this release.
-- add ability to place a section between releases with custom markdown, eg to
-  explain changes in the version numbering scheme or other important
-  information.
+- add ability to place a text block between specific releases with custom
+  markdown, eg to explain changes in the version numbering scheme or other
+  important information.
 - Allow to add a text block to the 'Breaking Changes' section. Should be added
   to the config file.
 - Add config option to add a custom text block to specfic releases.
@@ -75,6 +75,8 @@ in the next release.
   flag.
 - allow to use `Git TAGS` instead of `GitHub Releases` to generate the
   changelog. some projects don't use GitHub releases, but do use tags.
+- :rocket: add option to limit how many 'depencency' PRs are shown for each
+  release. Default to 10.
 
 ## Improve existing functionality
 
@@ -101,6 +103,12 @@ in the next release.
   does not grate so badly with the auto-generated headings.
 - in some cases the `full-changelog` does not get removed from the existing body
   properly depending on how it is formatted.
+
+## Refactoring
+
+- The whole code base needs a bit of refectoring to tidy the code and remove some
+of the duplication. This is a low priority but should be done at some point.
+Priority to the actual 'ChangeLog' class.
 
 ## Documentation
 

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -524,6 +524,10 @@ This option allows you to specify the maximum number of dependency updates to
 show for each release. By default this is set to `10`, but you can use the
 `--max-depends` or `-m` option to change this.
 
+If you use [Dependabot](https://github.com/apps/dependabot){:target="_blank"} to
+handle your dependency updates, this setting can be useful to limit the noise in
+the changelog.
+
 !!! tip ""
 
     :sparkles: Equivalent to the `max_depends` setting in the config file.

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -304,6 +304,7 @@ Current available options are:
 | `extend_ignored`        | List of labels to add to ignored   | `[]`          |
 | `allowed_labels`        | List of labels to allow            | `[]`          |
 | `ignored_users`         | List of usernames to ignore        | `[]`          |
+| `max_depends`           | Max dependency updates per Release | `10`          |
 | _`schema_version`_      | _Configuration schema version_     | _`1`_         |
 
 !!! tip "Config file schema version"
@@ -339,6 +340,7 @@ ignore_items = [123, 456] # (3)!
 extend_ignored = ["testing"]
 allowed_labels = ["question"]
 ignored_users = ["pre-commit-ci[bot]"]
+max_depends = 15
 ```
 
 1. :bulb: This is the only required setting, the others are optional.
@@ -515,6 +517,16 @@ section. By default the order is `newest_first`, but you can use the
 !!! tip ""
 
     :sparkles: Equivalent to the `item_order` setting in the config file.
+
+### `--max-depends` / `-m`
+
+This option allows you to specify the maximum number of dependency updates to
+show for each release. By default this is set to `10`, but you can use the
+`--max-depends` or `-m` option to change this.
+
+!!! tip ""
+
+    :sparkles: Equivalent to the `max_depends` setting in the config file.
 
 ## Future plans
 

--- a/github_changelog_md/config/settings.py
+++ b/github_changelog_md/config/settings.py
@@ -37,6 +37,7 @@ class Settings(TOMLSettings):
     allowed_labels: Optional[list[str]] = None
     ignore_strings: Optional[list[str]] = None
     ignored_users: Optional[list[str]] = None
+    max_depends: int = 10
 
 
 def get_settings_object() -> Settings:

--- a/github_changelog_md/main.py
+++ b/github_changelog_md/main.py
@@ -119,6 +119,16 @@ def main(
         ),
         show_default=False,
     ),
+    max_depends: Optional[int] = typer.Option(
+        None,
+        "--max-depends",
+        "-m",
+        help=(
+            "Maximum number of dependency updates to show in the Changelog. "
+            "Defaults to [bold]10[/bold]."
+        ),
+        show_default=False,
+    ),
 ) -> None:
     """Generate your CHANGELOG file Automatically from GitHub."""
     if version:
@@ -159,6 +169,9 @@ def main(
         "show_issues": settings.show_issues if issues is None else issues,
         "item_order": settings.item_order if item_order is None else item_order,
         "ignore_items": settings.ignore_items if ignore == [] else ignore,
+        "max_depends": settings.max_depends
+        if max_depends is None
+        else max_depends,
     }
 
     changelog = ChangeLog(repo, options)


### PR DESCRIPTION
Sometimes, if you have a decent time between releases, the number of Dependency updates by dependabot goes a bit mental. This will limit them to a maximum number; the default is 10.

A note is added to the list if it is truncated.