### PR TITLE
Add diff and patch

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -64,9 +64,9 @@ in the next release.
   line, since this is a side-effect of importing the settings library.`\]
 - offer to create any missing GitHub labels for the repo. This will prob require
   adding extra permissions to the PAT.
-- add `patch` and `diff` links to each release. Its pretty easy to do this -
-  just add `.patch` or `.diff` to the end of the '3-dot' url we generate for
-  each release anyway. Optional.
+- :rocket: add `patch` and `diff` links to each release. Its pretty easy to do
+  this - just add `.patch` or `.diff` to the end of the '3-dot' url we generate
+  for each release anyway. Optional.
 - option to mark a release as 'yanked', possibly with a custom message.
 - :rocket: list of usernames that should be ignored when generating the
   changelog. This will be useful for bots, particularly the `pre-commit` bot.

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -305,6 +305,8 @@ Current available options are:
 | `allowed_labels`        | List of labels to allow            | `[]`          |
 | `ignored_users`         | List of usernames to ignore        | `[]`          |
 | `max_depends`           | Max dependency updates per Release | `10`          |
+| `show_diff`             | Show diff links for each Release   | `True`        |
+| `show_patch`            | Show patch links for each Release  | `True`        |
 | _`schema_version`_      | _Configuration schema version_     | _`1`_         |
 
 !!! tip "Config file schema version"
@@ -341,6 +343,7 @@ extend_ignored = ["testing"]
 allowed_labels = ["question"]
 ignored_users = ["pre-commit-ci[bot]"]
 max_depends = 15
+show_patch = false
 ```
 
 1. :bulb: This is the only required setting, the others are optional.
@@ -531,6 +534,25 @@ the changelog.
 !!! tip ""
 
     :sparkles: Equivalent to the `max_depends` setting in the config file.
+
+### `--show-diff` / `--no-show-diff`
+
+Choose whether to show the diff links for each release. By default this will be
+shown (`--show-diff`), but you can use the `--no-show-diff` option to hide them.
+
+!!! tip ""
+
+    :sparkles: Equivalent to the `show_diff` setting in the config file.
+
+### `--show-patch` / `--no-show-patch`
+
+Choose whether to show the patch links for each release. By default this will be
+shown (`--show-patch`), but you can use the `--no-show-patch` option to hide
+them.
+
+!!! tip ""
+
+    :sparkles: Equivalent to the `show_patch` setting in the config file.`
 
 ## Future plans
 

--- a/github_changelog_md/changelog/changelog.py
+++ b/github_changelog_md/changelog/changelog.py
@@ -427,8 +427,19 @@ class ChangeLog:
         f.write(
             f"[`Full Changelog`]"
             f"({self.repo_data.html_url}/compare/"
-            f"{release_tag.tag_name}...{prev_release})\n\n",
+            f"{release_tag.tag_name}...{prev_release})",
         )
+        if self.options["show_diff"]:
+            f.write(
+                f" | [`Diff`]({self.repo_data.html_url}/compare/"
+                f"{release_tag.tag_name}...{prev_release}.diff)",
+            )
+        if self.options["show_patch"]:
+            f.write(
+                f" | [`Patch`]({self.repo_data.html_url}/compare/"
+                f"{release_tag.tag_name}...{prev_release}.patch)",
+            )
+        f.write("\n\n")
 
     def print_prs(
         self,

--- a/github_changelog_md/config/settings.py
+++ b/github_changelog_md/config/settings.py
@@ -38,6 +38,8 @@ class Settings(TOMLSettings):
     ignore_strings: Optional[list[str]] = None
     ignored_users: Optional[list[str]] = None
     max_depends: int = 10
+    show_diff: bool = True
+    show_patch: bool = True
 
 
 def get_settings_object() -> Settings:

--- a/github_changelog_md/main.py
+++ b/github_changelog_md/main.py
@@ -129,6 +129,22 @@ def main(
         ),
         show_default=False,
     ),
+    show_diff: Optional[bool] = typer.Option(
+        default=None,
+        help=(
+            "Show the diff of the PRs and Issues in the Changelog, defaults "
+            "to [bold]True[/bold]."
+        ),
+        show_default=False,
+    ),
+    show_patch: Optional[bool] = typer.Option(
+        default=None,
+        help=(
+            "Show the patch of the PRs and Issues in the Changelog, defaults "
+            "to [bold]True[/bold]."
+        ),
+        show_default=False,
+    ),
 ) -> None:
     """Generate your CHANGELOG file Automatically from GitHub."""
     if version:
@@ -172,6 +188,8 @@ def main(
         "max_depends": settings.max_depends
         if max_depends is None
         else max_depends,
+        "show_diff": settings.show_diff if show_diff is None else show_diff,
+        "show_patch": settings.show_patch if show_patch is None else show_patch,
     }
 
     changelog = ChangeLog(repo, options)


### PR DESCRIPTION
Add `Diff` and/or `Patch` links to each release. Defaults to True but can be controlled from the Command Line and the Configuration File.