### PR TITLE
Add `intro_text` option to display a block of text at the top of the Changelog

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -35,7 +35,7 @@ in the next release.
 - Allow to add a text block to the 'Breaking Changes' section. Should be added
   to the config file.
 - Add config option to add a custom text block to specfic releases.
-- Add an option to add a custom text block to the top of the changelog.
+- :rocket: Add an option to add a custom text block to the top of the changelog.
 - investigate adding caching of the GitHub API calls to speed up the process.
 - for the `--contrib` option, allow to use an existing file with comment markers
   in the file to indicate where to add the names. Provide a default file with

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -262,6 +262,36 @@ ignored_users = ["pre-commit-ci[bot]"]
 This is a list of strings and is optional. If you do not specify this setting,
 all users will be included. This is NO command line equivalent for this setting.
 
+## Add an introductory paragraph
+
+You can add an introductory paragraph to the top of the changelog, using the
+`intro_text` setting in the config file. For example, if you want to add a paragraph
+to the top of the changelog, you could add the following to your config file:
+
+```toml
+intro_text = """
+This is an introductory paragraph that will be added to the top of the
+changelog.
+"""
+```
+
+As seen above, you can use triple quotes to add a multi-line paragraph. If you
+only have one line of text, use normal quotes:
+
+```toml
+intro_text = "This is the project Changelog."
+```
+
+!!! tip "Tip"
+
+    This text is [Markdown](https://www.markdownguide.org/){:target="_blank"}
+    formatted, so you can use any Markdown formatting you want. Remember that a
+    single return in Markdown is ignored, so if you want a blank line between
+    paragraphs, you need to add two returns.
+
+The default value for this setting is an empty string, so if you do not specify
+this setting, no introductory paragraph will be added.
+
 ## Configuration File
 
 As mentioned in the [Installation](installation.md) section, this tool uses a
@@ -307,6 +337,7 @@ Current available options are:
 | `max_depends`           | Max dependency updates per Release | `10`          |
 | `show_diff`             | Show diff links for each Release   | `True`        |
 | `show_patch`            | Show patch links for each Release  | `True`        |
+| `intro_text`            | Introductory paragraph             | `""`          |
 | _`schema_version`_      | _Configuration schema version_     | _`1`_         |
 
 !!! tip "Config file schema version"
@@ -344,6 +375,10 @@ allowed_labels = ["question"]
 ignored_users = ["pre-commit-ci[bot]"]
 max_depends = 15
 show_patch = false
+intro_text = """
+This is a log of all the changes that have been made to the project since the
+first release. It is automatically generated for each release.
+"""
 ```
 
 1. :bulb: This is the only required setting, the others are optional.

--- a/github_changelog_md/changelog/changelog.py
+++ b/github_changelog_md/changelog/changelog.py
@@ -259,6 +259,9 @@ class ChangeLog:
         ) as f:
             f.write("# Changelog\n\n")
 
+            if self.settings.intro_text:
+                f.write(f"{self.settings.intro_text}\n\n")
+
             if not self.options["show_depends"]:
                 f.write(
                     "*Dependency updates are excluded from this changelog, "

--- a/github_changelog_md/config/settings.py
+++ b/github_changelog_md/config/settings.py
@@ -40,6 +40,7 @@ class Settings(TOMLSettings):
     max_depends: int = 10
     show_diff: bool = True
     show_patch: bool = True
+    intro_text: str = ""
 
 
 def get_settings_object() -> Settings:

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -8,9 +8,12 @@ theme:
     accent: blue
   features:
     - navigation.footer
-    - navigation.expand
+    # - navigation.expand
     - content.code.copy
     - content.code.annotate
+    - navigation.tracking
+    - navigation.top
+    - toc.follow
   icon:
     logo: material/history
   favicon: images/favicon.ico
@@ -25,8 +28,8 @@ copyright: © 2023 Grant Ramsay (Seapagan)
 
 plugins:
   - search
-  - git-revision-date-localized:
-      enable_creation_date: true
+  # - git-revision-date-localized:
+  #     enable_creation_date: true
   - minify:
       minify_html: true
       minify_css: true


### PR DESCRIPTION
By default, no text is placed between the heading and the first release. This option allows you to add a block of general summary text there.