### PR TITLE
Add an optional text block between releases

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -29,9 +29,10 @@ in the next release.
   like "First release" or "Initial release" or "Initial commit" or something
   (configurable) to indicate that this is the first release and nothing to
   compare to. Optionally hide all PR, Issue and commit links in this release.
-- :fire: Add ability to place a text block **between** specific releases with
+- :rocket: Add ability to place a text block **between** specific releases with
   custom markdown, eg to explain changes in the version numbering scheme or
-  other important information. can be `before` or `after` the specified release.
+  other important information. It is placed **before** the specified release and
+  is not available for the 'Unreleased' section.
 - :rocket: Add config option to add a custom text block to specfic releases. This
   is inside the release as opposed to the option above which is outside (before
   or after) the release.

--- a/docs/usage/config_file.md
+++ b/docs/usage/config_file.md
@@ -47,6 +47,7 @@ Current available options are:
 | `show_patch`            | Show patch links for each Release  | `True`        |
 | `intro_text`            | Introductory paragraph             | `""`          |
 | `release_text`          | Add text to a specific release     | `[]`          |
+| `release_text_before`   | Add text before a specific release | `[]`          |
 | `yanked`                | Mark specific release(s) as Yanked | `[]`          |
 | _`schema_version`_      | _Configuration schema version_     | _`1`_         |
 

--- a/docs/usage/usage.md
+++ b/docs/usage/usage.md
@@ -352,6 +352,27 @@ Below is an example of how this looks in the changelog for this project:
 
     ![Release Text Example](../images/release_text.png)
 
+## Adding text between releases
+
+You can add a text section between releases, using the `releases_text_before`
+setting in the config file. For example, if you want to add a paragraph between
+the `1.2.3` and `1.2.4` releases, you could add the following to your config
+file:
+
+```toml
+[[github_changelog.md.release_text_before]]
+release = "1.2.4"
+text = "This is a paragraph between the 1.2.3 and 1.2.4 releases."
+```
+
+The `release` value is the release that the text will be added **before**,
+working from top to bottom in the changelog. So in the above example, the text
+will be between the `1.2.4` and `1.2.5` releases.
+
+You can either use the inline or verbose format for this setting, depending on
+how much text you want to add. There is NO command-line equivalent for this
+setting.
+
 ## Mark a release as "Yanked"
 
 Sometimes you may need to mark a release as "Yanked" (or "Retracted") for

--- a/github_changelog_md/changelog/changelog.py
+++ b/github_changelog_md/changelog/changelog.py
@@ -361,6 +361,23 @@ class ChangeLog:
         if self.prev_release:
             self.generate_diff_url(f, self.prev_release, release)
 
+        if self.settings.release_text_before and release.tag_name in [
+            release_text["release"].strip()
+            for release_text in self.settings.release_text_before
+        ]:
+            f.write("---\n\n")
+            f.write(
+                next(
+                    (
+                        release_text["text"]
+                        for release_text in self.settings.release_text_before
+                        if release_text["release"].strip() == release.tag_name
+                    ),
+                    "",
+                )
+            )
+            f.write("\n---\n\n")
+
         text_date = release.created_at.date().strftime(
             self.settings.date_format
         )

--- a/github_changelog_md/config/settings.py
+++ b/github_changelog_md/config/settings.py
@@ -43,6 +43,7 @@ class Settings(TOMLSettings):
     intro_text: str = ""
     yanked: Optional[list[dict[str, str]]] = None
     release_text: Optional[list[dict[str, str]]] = None
+    release_text_before: Optional[list[dict[str, str]]] = None
 
 
 def get_settings_object() -> Settings:


### PR DESCRIPTION
Allow adding text (Markdown) blocks between different releases.