### PR TITLE
fix spacing issues caused by extra line when deps are truncated

### DIFF
--- a/github_changelog_md/changelog/changelog.py
+++ b/github_changelog_md/changelog/changelog.py
@@ -577,7 +577,6 @@ class ChangeLog:
                         f"([#{pr.number}]({pr.html_url})) "
                         f"by [{pr.user.login}]({pr.user.html_url})\n",
                     )
-                f.write("\n")
                 if (
                     is_dependencies
                     and len(sorted_prs) > self.options["max_depends"]
@@ -586,8 +585,9 @@ class ChangeLog:
                         len(sorted_prs) - self.options["max_depends"]
                     )
                     f.write(
-                        f"- *and {hidden_updates} more dependency updates*\n\n",
+                        f"- *and {hidden_updates} more dependency updates*\n",
                     )
+                f.write("\n")
 
     def ignore_items(
         self, items: list[PullRequest | Issue]


### PR DESCRIPTION
An extra '`\n`' causes the '_x more dependency updates_' item to be a separate list than the proceeding. This causes spacing issues when rendered in GitHub and others.
