### PR TITLE
For a closed issue, show the name who closed it not who opened it

### DIFF
--- a/github_changelog_md/changelog/changelog.py
+++ b/github_changelog_md/changelog/changelog.py
@@ -504,7 +504,7 @@ class ChangeLog:
             f.write(
                 f"- {escaped_title} "
                 f"([#{issue.number}]({issue.html_url})) "
-                f"by [{issue.user.login}]({issue.user.html_url})\n",
+                f"by [{issue.closed_by.login}]({issue.closed_by.html_url})\n",
             )
         f.write("\n")
 


### PR DESCRIPTION
showing the user who closed an issue makes more sense in a CHANGELOG than showing the user who opened it.