### PR TITLE
Don't print the release title if it is the same as the tag

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -73,10 +73,7 @@ in the next release.
 - Add option to use Markdown header levels for the section headings instead of
   the default **bold** text. This is more correct for Markdown and will pass
   linters.
-- Display release title in the release header instead of body. If it is the same
-  as the release version (after stripping the 'v' prefix if exists), don't show
-  it. To help, add an option to specify a custom release prefix on a project
-  level, and an option in the indicidual `changelog_generator.release_text`
+- Add an option in the individual `changelog_generator.release_text`
   sections to hide the title for that release.
 
 ## Known Issues

--- a/github_changelog_md/changelog/changelog.py
+++ b/github_changelog_md/changelog/changelog.py
@@ -31,6 +31,7 @@ from github_changelog_md.helpers import (
     get_index_of_tuple,
     get_section_name,
     header,
+    title_unique,
 )
 
 if TYPE_CHECKING:  # pragma: no cover
@@ -390,8 +391,13 @@ class ChangeLog:
             )
 
         f.write("\n\n")
-        if release.title != release.tag_name and release.title:
-            f.write(f"**_'{cap_first_letter(release.title.strip())}'_**\n\n")
+
+        # write the release title if it is different from the tag name
+        # and it is not empty. We may need to strip any leading alpha character
+        # from the title (eg 'v' or 'V')
+        if title_unique(release):
+            f.write(f"**_{cap_first_letter(release.title.strip())}_**\n\n")
+
         pr_list: list[PullRequest] = self.pr_by_release.get(release.id, [])
         issue_list: list[Issue] = self.issue_by_release.get(release.id, [])
 

--- a/github_changelog_md/helpers.py
+++ b/github_changelog_md/helpers.py
@@ -5,11 +5,15 @@ from __future__ import annotations
 import sys
 from importlib import metadata, resources
 from pathlib import Path
+from typing import TYPE_CHECKING
 
 import rtoml
 from rich import print  # pylint: disable=redefined-builtin
 
 from github_changelog_md.constants import SECTIONS, ExitErrors, SectionHeadings
+
+if TYPE_CHECKING:  # pragma: no cover
+    from github.GitRelease import GitRelease
 
 
 def get_toml_path() -> Path:
@@ -102,3 +106,26 @@ def get_index_of_tuple(
 
     error_msg = f"'{value}' is not in the supplied list of Tuples"
     raise ValueError(error_msg)
+
+
+def strip_first_alpha_char(version_string: str) -> str:
+    """Strip the first character from a string if it is a letter."""
+    if version_string and version_string[0].isalpha():
+        return version_string[1:]
+    return version_string
+
+
+def title_unique(release: GitRelease) -> bool:
+    """Ensures that the release title and tag name are not the same.
+
+    It will remove the first alpha character from the title and tag (if it is a
+    letter) and compare the two strings. Returns True if they are different,
+    False otherwise.
+
+    It will also return False if the title or tag name is empty.
+    """
+    if not release.title or not release.tag_name:
+        return False
+    return strip_first_alpha_char(release.title) != strip_first_alpha_char(
+        release.tag_name
+    )

--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -16,6 +16,8 @@ from github_changelog_md.helpers import (
     get_repo_name,
     get_section_name,
     header,
+    strip_first_alpha_char,
+    title_unique,
 )
 
 if TYPE_CHECKING:
@@ -184,3 +186,28 @@ class TestHelpers:
         assert "'Introduction' is not in the supplied list of Tuples" in str(
             exc_info.value
         ), "Expected a ValueError, 'Introduction' was not found in empty list"
+
+    def test_strip_first_alpha(self) -> None:
+        """Test strip_first_alpha_char function."""
+        assert strip_first_alpha_char("v1.0.0") == "1.0.0"
+        assert strip_first_alpha_char("1.0.0") == "1.0.0"
+        assert strip_first_alpha_char("a1.0.0") == "1.0.0"
+        assert strip_first_alpha_char("a") == ""
+        assert strip_first_alpha_char("") == ""
+
+    @pytest.mark.parametrize(
+        ("title", "tag_name", "expected"),
+        [
+            ("v1.0.0", "1.0.0", False),
+            ("v1.0.0", "2.0.0", True),
+            ("V1.0.0", "", False),
+            ("", "1.0.0", False),
+        ],
+    )
+    def test_title_unique(self, mocker, title, tag_name, expected) -> None:
+        """Test the title_unique function."""
+        release = mocker.Mock()
+        release.title = title
+        release.tag_name = tag_name
+
+        assert title_unique(release) is expected


### PR DESCRIPTION
This also takes into account a single character alpha prefix on either.