### PR TITLE
Refactor changelog core architecture

### DIFF
--- a/docs/usage/basic.md
+++ b/docs/usage/basic.md
@@ -36,8 +36,8 @@ $ github-changelog-md --repo <repo-name>
 !!! note "Automatic repository name detection"
 
     If you do not specify a repository name, the tool will try to determine the
-    repository name from the current folder if it is a git repository. Failing
-    that it will exit.
+    repository owner and name from the current folder if it is a git repository
+    with a GitHub `origin` remote. Failing that it will exit.
 
     Just run the command from the root of the repository you want to generate
     the changelog for, with no options:

--- a/docs/usage/cli_options.md
+++ b/docs/usage/cli_options.md
@@ -142,8 +142,8 @@ $ github-changelog-md --ignore 123 --ignore 456
 ## `--item-order` / `-i`
 
 This option allows you to specify the order of the PRs and Issues in each
-section. By default the order is `newest_first`, but you can use the
-`--item-order` or `-i` option to change this to `oldest_first`.
+section. By default the order is `newest-first`, but you can use the
+`--item-order` or `-i` option to change this to `oldest-first`.
 
 !!! tip ""
 
@@ -154,6 +154,9 @@ section. By default the order is `newest_first`, but you can use the
 This option allows you to specify the maximum number of dependency updates to
 show for each release. By default this is set to `10`, but you can use the
 `--max-depends` or `-m` option to change this.
+
+Set this to `0` to hide individual dependency update entries while still
+showing the summary count for the release.
 
 If you use [Dependabot](https://github.com/apps/dependabot){:target="_blank"} to
 handle your dependency updates, this setting can be useful to limit the noise in

--- a/docs/usage/config_file.md
+++ b/docs/usage/config_file.md
@@ -36,13 +36,13 @@ Current available options are:
 | `extend_sections_index` | Index to insert custom sections    | dynamic [^1]  |
 | `rename_sections`       | Rename default section headers     | `[]`          |
 | `date_format`           | Date format for release dates      | `%Y-%m-%d`    |
-| `item_order`            | Order of PR/Issues in each section | `newest_first`|
+| `item_order`            | Order of PR/Issues in each section | `newest-first`|
 | `ignore_items`          | List of PRs/Issues to ignore       | `[]`          |
 | `ignored_labels`        | List of labels to ignore           | See above     |
 | `extend_ignored`        | List of labels to add to ignored   | `[]`          |
 | `allowed_labels`        | List of labels to allow            | `[]`          |
 | `ignored_users`         | List of usernames to ignore        | `[]`          |
-| `max_depends`           | Max dependency updates per Release | `10`          |
+| `max_depends`           | Max dependency updates per Release | `10` [^2]     |
 | `show_diff`             | Show diff links for each Release   | `True`        |
 | `show_patch`            | Show patch links for each Release  | `True`        |
 | `intro_text`            | Introductory paragraph             | `""`          |
@@ -83,7 +83,7 @@ extend_sections = [
 extend_sections_index = 3
 rename_sections = [{ old = "Enhancements", new = "New Features" }]
 date_format = "%d %B %Y" # (2)!
-item_order = "oldest_first"
+item_order = "oldest-first"
 ignore_items = [123, 456] # (3)!
 extend_ignored = ["testing"]
 allowed_labels = ["question"]
@@ -136,6 +136,10 @@ values specified on the command line).
     `Dependency Updates` section, but you can change this by setting the
     `extend_sections_index` value. See the
     [Custom Sections](options.md#custom-sections) section for more details.
+
+[^2]:
+    Set this to `0` to hide individual dependency update entries while still
+    showing the summary count for the release.
 
 ## Real-world Example
 

--- a/github_changelog_md/changelog/__init__.py
+++ b/github_changelog_md/changelog/__init__.py
@@ -1,5 +1,5 @@
 """Init file for changelog module."""
 
-from .changelog import ChangeLog
+from .changelog import ChangeLog, build_release_text_cache
 
-__all__ = ["ChangeLog"]
+__all__ = ["ChangeLog", "build_release_text_cache"]

--- a/github_changelog_md/changelog/bucketing.py
+++ b/github_changelog_md/changelog/bucketing.py
@@ -1,0 +1,140 @@
+"""Pure changelog item bucketing logic."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import TYPE_CHECKING, Generic, Protocol, TypeVar
+
+if TYPE_CHECKING:  # pragma: no cover
+    import datetime
+    from collections.abc import Callable
+
+    from github_changelog_md.changelog.models import (
+        ChangelogIssue,
+        ChangelogPullRequest,
+        ChangelogRelease,
+        ChangelogUser,
+    )
+
+
+class BucketableItem(Protocol):
+    """Item fields required for release bucketing."""
+
+    @property
+    def id(self) -> int:
+        """Return the item id."""
+        ...
+
+    @property
+    def user(self) -> ChangelogUser:
+        """Return the item author."""
+        ...
+
+
+ChangelogItem = TypeVar("ChangelogItem", bound=BucketableItem)
+
+
+@dataclass(frozen=True, slots=True)
+class BucketedItems(Generic[ChangelogItem]):
+    """Items assigned to releases plus items newer than the latest release."""
+
+    by_release: dict[int, list[ChangelogItem]]
+    unreleased: list[ChangelogItem]
+
+
+def get_unreleased_cutoff(
+    releases: list[ChangelogRelease],
+    fallback_date: datetime.datetime,
+) -> datetime.datetime:
+    """Return the date after which items are considered unreleased."""
+    if not releases:
+        return fallback_date
+    return max(releases, key=lambda release: release.created_at).created_at
+
+
+def bucket_pull_requests(
+    releases: list[ChangelogRelease],
+    pull_requests: list[ChangelogPullRequest],
+    unreleased_cutoff: datetime.datetime,
+    ignored_users: list[str],
+) -> BucketedItems[ChangelogPullRequest]:
+    """Assign pull requests to releases by merge date."""
+    return _bucket_items(
+        releases=releases,
+        items=pull_requests,
+        unreleased_cutoff=unreleased_cutoff,
+        ignored_users=ignored_users,
+        item_date=lambda pull_request: pull_request.merged_at,
+    )
+
+
+def bucket_issues(
+    releases: list[ChangelogRelease],
+    issues: list[ChangelogIssue],
+    unreleased_cutoff: datetime.datetime,
+    ignored_users: list[str],
+) -> BucketedItems[ChangelogIssue]:
+    """Assign issues to releases by close date."""
+    return _bucket_items(
+        releases=releases,
+        items=issues,
+        unreleased_cutoff=unreleased_cutoff,
+        ignored_users=ignored_users,
+        item_date=lambda issue: issue.closed_at,
+    )
+
+
+def _bucket_items(
+    releases: list[ChangelogRelease],
+    items: list[ChangelogItem],
+    unreleased_cutoff: datetime.datetime,
+    ignored_users: list[str],
+    item_date: Callable[[ChangelogItem], datetime.datetime | None],
+) -> BucketedItems[ChangelogItem]:
+    """Assign dated items to the first release after their date."""
+    by_release: dict[int, list[ChangelogItem]] = {
+        release.id: [] for release in releases
+    }
+    sorted_releases = sorted(releases, key=lambda release: release.created_at)
+    sorted_items = sorted(
+        items,
+        key=lambda item: _date_or_cutoff(item, item_date, unreleased_cutoff),
+    )
+    ignored_user_set = set(ignored_users)
+    seen: set[int] = set()
+
+    for release in sorted_releases:
+        for item in sorted_items:
+            date = item_date(item)
+            if (
+                date
+                and date <= release.created_at
+                and item.id not in seen
+                and item.user.login not in ignored_user_set
+            ):
+                by_release[release.id].append(item)
+                seen.add(item.id)
+
+    unreleased: list[ChangelogItem] = []
+    for item in sorted_items:
+        date = item_date(item)
+        if (
+            date
+            and date > unreleased_cutoff
+            and item.id not in seen
+            and item.user.login not in ignored_user_set
+        ):
+            unreleased.append(item)
+    return BucketedItems(by_release=by_release, unreleased=unreleased)
+
+
+def _date_or_cutoff(
+    item: ChangelogItem,
+    item_date: Callable[[ChangelogItem], datetime.datetime | None],
+    unreleased_cutoff: datetime.datetime,
+) -> datetime.datetime:
+    """Return an item's date or the cutoff for undated items."""
+    date = item_date(item)
+    if date is None:
+        return unreleased_cutoff
+    return date

--- a/github_changelog_md/changelog/changelog.py
+++ b/github_changelog_md/changelog/changelog.py
@@ -11,13 +11,18 @@ import os
 import sys
 from dataclasses import dataclass, field
 from pathlib import Path
-from typing import TYPE_CHECKING, Any, Literal, NoReturn
+from typing import TYPE_CHECKING, Any, Literal, NoReturn, TypeAlias
 
 import typer
 from github import Auth, Github, GithubException
 from github.GitRelease import GitRelease
 from rich import print as rprint
 
+from github_changelog_md.changelog.models import (
+    ChangelogIssue,
+    ChangelogPullRequest,
+    ChangelogRelease,
+)
 from github_changelog_md.config import get_settings
 from github_changelog_md.constants import (
     CONTRIBUTORS_FILE,
@@ -45,6 +50,15 @@ if TYPE_CHECKING:  # pragma: no cover
     from github.PaginatedList import PaginatedList
     from github.PullRequest import PullRequest
     from github.Repository import Repository
+
+if TYPE_CHECKING:
+    Release: TypeAlias = GitRelease | ChangelogRelease
+    PullRequestItem: TypeAlias = PullRequest | ChangelogPullRequest
+    IssueItem: TypeAlias = Issue | ChangelogIssue
+else:
+    Release = GitRelease | ChangelogRelease
+    PullRequestItem = ChangelogPullRequest
+    IssueItem = ChangelogIssue
 
 
 def git_error(exc: GithubException) -> NoReturn:
@@ -98,15 +112,15 @@ class ChangeLog:
         self.ignored_labels: list[str]
 
         self.repo_data: Repository
-        self.repo_releases: list[GitRelease]
+        self.repo_releases: list[Release]
         self.repo_prs: PaginatedList[PullRequest]
         self.repo_issues: PaginatedList[Issue]
-        self.pr_by_release: dict[int, list[PullRequest]]
-        self.issue_by_release: dict[int, list[Issue]]
-        self.prev_release: GitRelease | Literal["HEAD"] | None = None
-        self.filtered_repo_issues: list[Issue]
-        self.unreleased: list[PullRequest]
-        self.unreleased_issues: list[Issue]
+        self.pr_by_release: dict[int, list[PullRequestItem]]
+        self.issue_by_release: dict[int, list[IssueItem]]
+        self.prev_release: Release | Literal["HEAD"] | None = None
+        self.filtered_repo_issues: list[IssueItem]
+        self.unreleased: list[PullRequestItem]
+        self.unreleased_issues: list[IssueItem]
         self.contributors: list[NamedUser]
         self.release_text_cache = ReleaseTextCache(
             yanked_by_release=self.build_release_lookup(
@@ -378,7 +392,7 @@ class ChangeLog:
     def process_release(
         self,
         f: TextIOWrapper,
-        release: GitRelease,
+        release: Release,
     ) -> None:
         """Process a single release."""
         if (
@@ -408,8 +422,8 @@ class ChangeLog:
         if title_unique(release):
             f.write(f"**_{cap_first_letter(release.title.strip())}_**\n\n")
 
-        pr_list: list[PullRequest] = self.pr_by_release.get(release.id, [])
-        issue_list: list[Issue] = self.issue_by_release.get(release.id, [])
+        pr_list: list[PullRequestItem] = self.pr_by_release.get(release.id, [])
+        issue_list: list[IssueItem] = self.issue_by_release.get(release.id, [])
 
         # show any release text that is defined for this release
         self.show_release_text(f, release)
@@ -433,7 +447,7 @@ class ChangeLog:
         if not issue_list and not pr_list:
             self.get_release_body(f, release)
 
-    def check_yanked(self, f: TextIOWrapper, release: GitRelease) -> None:
+    def check_yanked(self, f: TextIOWrapper, release: Release) -> None:
         """Note if this release has been yanked, and the reason why."""
         if release.tag_name in self.release_text_cache.yanked_by_release:
             f.write(" **[`YANKED`]**\n\n")
@@ -444,7 +458,7 @@ class ChangeLog:
                 f"{self.release_text_cache.yanked_by_release[release.tag_name]}"
             )
 
-    def show_before_text(self, f: TextIOWrapper, release: GitRelease) -> None:
+    def show_before_text(self, f: TextIOWrapper, release: Release) -> None:
         """Shows text before this release if it exists."""
         if (
             release.tag_name
@@ -461,13 +475,10 @@ class ChangeLog:
     def show_release_text(
         self,
         f: TextIOWrapper,
-        release: str | GitRelease,
+        release: str | Release,
     ) -> None:
         """Print the release_text if it exists."""
-        if isinstance(release, GitRelease):
-            tag_name = release.tag_name
-        else:
-            tag_name = release
+        tag_name = release if isinstance(release, str) else release.tag_name
 
         if tag_name in self.release_text_cache.release_text_by_release:
             f.write(self.release_text_cache.release_text_by_release[tag_name])
@@ -476,7 +487,7 @@ class ChangeLog:
     def get_release_body(
         self,
         f: TextIOWrapper,
-        release: GitRelease,
+        release: Release,
     ) -> None:
         """Read the GitHub release body.
 
@@ -504,7 +515,7 @@ class ChangeLog:
     def rprint_issues(
         self,
         f: TextIOWrapper,
-        issue_list: list[Issue],
+        issue_list: list[IssueItem],
     ) -> None:
         """Print all the closed issues for a given release."""
         visible_issues = self.ignore_items(list(issue_list))
@@ -540,11 +551,11 @@ class ChangeLog:
     def generate_diff_url(
         self,
         f: TextIOWrapper,
-        prev_release: GitRelease | str,
-        release_tag: GitRelease,
+        prev_release: Release | str,
+        release_tag: Release,
     ) -> None:
         """Generate a GitHub 3-dots link to the diff between two releases."""
-        if isinstance(prev_release, GitRelease):
+        if not isinstance(prev_release, str):
             prev_release = prev_release.tag_name
         elif self.options["next_release"]:
             prev_release = self.options["next_release"]
@@ -568,7 +579,7 @@ class ChangeLog:
     def rprint_prs(
         self,
         f: TextIOWrapper,
-        pr_list: list[PullRequest],
+        pr_list: list[PullRequestItem],
     ) -> None:
         """Print all the PRs for a given release.
 
@@ -640,8 +651,8 @@ class ChangeLog:
                 f.write("\n")
 
     def ignore_items(
-        self, items: list[PullRequest | Issue]
-    ) -> list[PullRequest | Issue]:
+        self, items: list[PullRequestItem | IssueItem]
+    ) -> list[PullRequestItem | IssueItem]:
         """Ignore any PRs or Issues that have been marked as hidden."""
         if not self.options["ignore_items"]:
             return items
@@ -662,8 +673,8 @@ class ChangeLog:
         return items
 
     def get_release_sections(
-        self, pr_list: list[PullRequest]
-    ) -> dict[str, list[PullRequest]]:
+        self, pr_list: list[PullRequestItem]
+    ) -> dict[str, list[PullRequestItem]]:
         """Return a dictionary of PRs sorted into sections.
 
         This handles the PRs that have a label, we handle the PRs that don't
@@ -683,7 +694,7 @@ class ChangeLog:
             for heading, section_label in self.sections
         }
 
-    def link_issues(self) -> dict[int, list[Issue]]:
+    def link_issues(self) -> dict[int, list[IssueItem]]:
         """Link Issues to their respective Release.
 
         This will create a dictionary with the key on the release id and
@@ -694,7 +705,7 @@ class ChangeLog:
             "Release ... ",
             end="",
         )
-        issue_by_release: dict[int, list[Issue]] = {}
+        issue_by_release: dict[int, list[IssueItem]] = {}
         seen: set[int] = set()
         for release in self.repo_releases[::-1]:
             issue_by_release[release.id] = []
@@ -735,7 +746,7 @@ class ChangeLog:
             last_release_date = first_commit.commit.committer.date
         return last_release_date
 
-    def link_pull_requests(self) -> dict[int, list[PullRequest]]:
+    def link_pull_requests(self) -> dict[int, list[PullRequestItem]]:
         """Link Pull Requests to their respective Release.
 
         This will create a dictionary with the key on the release id and
@@ -746,7 +757,7 @@ class ChangeLog:
             "Release ... ",
             end="",
         )
-        pr_by_release: dict[int, list[PullRequest]] = {}
+        pr_by_release: dict[int, list[PullRequestItem]] = {}
         seen: set[int] = set()
         for release in self.repo_releases[::-1]:
             pr_by_release[release.id] = []
@@ -774,10 +785,10 @@ class ChangeLog:
         rprint(self.done_str)
         return pr_by_release
 
-    def filter_issues(self) -> list[Issue]:
+    def filter_issues(self) -> list[IssueItem]:
         """Filter out non-merged PRs and actual issues."""
         rprint("\n  [green]->[/green] Filtering Issues from PRs... ", end="")
-        filtered_repo_issues = [
+        filtered_repo_issues: list[IssueItem] = [
             issue for issue in self.repo_issues if not issue.pull_request
         ]
         rprint(self.done_str)
@@ -816,7 +827,7 @@ class ChangeLog:
             rprint(f"[green]{repo_prs.totalCount} Found[/green]")
             return repo_prs
 
-    def get_repo_releases(self) -> list[GitRelease]:
+    def get_repo_releases(self) -> list[Release]:
         """Get info on all the releases from GitHub."""
         rprint("  [green]->[/green] Getting Releases ... ", end="")
         try:

--- a/github_changelog_md/changelog/changelog.py
+++ b/github_changelog_md/changelog/changelog.py
@@ -85,6 +85,7 @@ def build_release_text_cache(settings: Settings) -> ReleaseTextCache:
         release_overrides_by_release=ChangeLog.build_release_lookup(
             settings.release_overrides,
             value_key="text",
+            strip_value=True,
         ),
     )
 

--- a/github_changelog_md/changelog/changelog.py
+++ b/github_changelog_md/changelog/changelog.py
@@ -28,6 +28,7 @@ from github_changelog_md.changelog.models import (
     ChangelogUser,
 )
 from github_changelog_md.changelog.renderer import ChangelogRenderer
+from github_changelog_md.config.validation import normalize_release_entries
 from github_changelog_md.constants import (
     CONTRIBUTORS_FILE,
     IGNORED_CONTRIBUTORS,
@@ -126,16 +127,11 @@ class ChangeLog:
         strip_value: bool = False,
     ) -> dict[str, str]:
         """Build a release-tag keyed lookup table for fast text lookups."""
-        if not values:
-            return {}
-
-        lookup: dict[str, str] = {}
-        for value in values:
-            release = value["release"].strip()
-            text = value[value_key].strip() if strip_value else value[value_key]
-            lookup[release] = text
-
-        return lookup
+        return normalize_release_entries(
+            values,
+            value_key,
+            strip_value=strip_value,
+        )
 
     def run(self) -> None:
         """Run the changelog.

--- a/github_changelog_md/changelog/changelog.py
+++ b/github_changelog_md/changelog/changelog.py
@@ -16,6 +16,11 @@ from typing import TYPE_CHECKING, Any, Literal, TypeAlias
 import typer
 from rich import print as rprint
 
+from github_changelog_md.changelog.bucketing import (
+    bucket_issues,
+    bucket_pull_requests,
+    get_unreleased_cutoff,
+)
 from github_changelog_md.changelog.models import (
     ChangelogIssue,
     ChangelogPullRequest,
@@ -678,44 +683,27 @@ class ChangeLog:
             end="",
         )
         issue_by_release: dict[int, list[IssueItem]] = {}
-        seen: set[int] = set()
-        for release in self.repo_releases[::-1]:
-            issue_by_release[release.id] = []
-            for issue in self.filtered_repo_issues:
-                if (
-                    issue.closed_at
-                    and issue.closed_at <= release.created_at
-                    and issue.id not in seen
-                    and issue.user.login not in self.settings.ignored_users
-                ):
-                    issue_by_release[release.id].append(issue)
-                    seen.add(issue.id)
-
-        # Add any issue more recent than the last release to a specific
-        # list. We need some special handling if there are no releases yet.
-        last_release_date = self.get_latest_release_date()
-
-        self.unreleased_issues = [
-            issue
-            for issue in self.filtered_repo_issues
-            if issue.closed_at
-            and issue.closed_at > last_release_date
-            and issue.id not in seen
-            and issue.user.login not in self.settings.ignored_users
-        ]
+        unreleased_cutoff = self.get_unreleased_cutoff()
+        bucketed = bucket_issues(
+            self.repo_releases,
+            self.filtered_repo_issues,
+            unreleased_cutoff,
+            self.settings.ignored_users,
+        )
+        issue_by_release.update(bucketed.by_release)
+        self.unreleased_issues = bucketed.unreleased
 
         rprint(self.done_str)
         return issue_by_release
 
-    def get_latest_release_date(self) -> datetime.datetime:
-        """Return the date of the latest release."""
-        try:
-            last_release_date = self.repo_releases[-1].created_at
-        except IndexError:
-            # there have been no releases yet, so we need to get the date of
-            # the first commit.
-            last_release_date = self.data_source.get_first_commit_date()
-        return last_release_date
+    def get_unreleased_cutoff(self) -> datetime.datetime:
+        """Return the date after which items are considered unreleased."""
+        if self.repo_releases:
+            return get_unreleased_cutoff(
+                self.repo_releases,
+                self.repo_releases[0].created_at,
+            )
+        return self.data_source.get_first_commit_date()
 
     def link_pull_requests(self) -> dict[int, list[PullRequestItem]]:
         """Link Pull Requests to their respective Release.
@@ -729,30 +717,15 @@ class ChangeLog:
             end="",
         )
         pr_by_release: dict[int, list[PullRequestItem]] = {}
-        seen: set[int] = set()
-        for release in self.repo_releases[::-1]:
-            pr_by_release[release.id] = []
-            for pr in self.repo_prs:
-                if (
-                    pr.merged_at
-                    and pr.merged_at <= release.created_at
-                    and pr.id not in seen
-                    and pr.user.login not in self.settings.ignored_users
-                ):
-                    pr_by_release[release.id].append(pr)
-                    seen.add(pr.id)
-        # Add any pull request more recent than the last release to a specific
-        # list. We need some special handling if there are no releases yet.
-        last_release_date = self.get_latest_release_date()
-
-        self.unreleased = [
-            pr
-            for pr in self.repo_prs
-            if pr.merged_at
-            and pr.merged_at > last_release_date
-            and pr.id not in seen
-            and pr.user.login not in self.settings.ignored_users
-        ]
+        unreleased_cutoff = self.get_unreleased_cutoff()
+        bucketed = bucket_pull_requests(
+            self.repo_releases,
+            self.repo_prs,
+            unreleased_cutoff,
+            self.settings.ignored_users,
+        )
+        pr_by_release.update(bucketed.by_release)
+        self.unreleased = bucketed.unreleased
         rprint(self.done_str)
         return pr_by_release
 

--- a/github_changelog_md/changelog/changelog.py
+++ b/github_changelog_md/changelog/changelog.py
@@ -6,7 +6,6 @@ This will encapsulate the logic for generating the changelog.
 from __future__ import annotations
 
 import contextlib
-import datetime
 import os
 import sys
 from dataclasses import dataclass, field
@@ -28,6 +27,7 @@ from github_changelog_md.changelog.models import (
     ChangelogRepository,
     ChangelogUser,
 )
+from github_changelog_md.changelog.renderer import ChangelogRenderer
 from github_changelog_md.constants import (
     CONTRIBUTORS_FILE,
     IGNORED_CONTRIBUTORS,
@@ -38,14 +38,12 @@ from github_changelog_md.constants import (
     SectionHeadings,
 )
 from github_changelog_md.helpers import (
-    cap_first_letter,
     get_index_of_tuple,
-    get_section_name,
     header,
-    title_unique,
 )
 
 if TYPE_CHECKING:  # pragma: no cover
+    import datetime
     from io import TextIOWrapper
 
     from github_changelog_md.changelog.github_data import GitHubDataSource
@@ -292,37 +290,12 @@ class ChangeLog:
 
         rprint("  [green]->[/green] Generating Changelog ... ", end="")
 
+        rendered_changelog = self._renderer().render()
         with Path(Path.cwd() / self.options["output_file"]).open(
             mode="w",
             encoding="utf-8",
         ) as f:
-            f.write("# Changelog\n\n")
-
-            if self.settings.intro_text:
-                f.write(f"{self.settings.intro_text}\n\n")
-
-            if not self.options["show_depends"]:
-                f.write(
-                    "*Dependency updates are excluded from this changelog, "
-                    "check each `Full Changelog` for details.*\n\n "
-                )
-
-            self.prev_release = None
-
-            if self.options["show_unreleased"]:
-                self.process_unreleased(f)
-
-            for release in self.repo_releases:
-                self.process_release(f, release)
-                self.prev_release = release
-
-            # add a link to this generator at the bottom of the changelog
-            f.write(
-                "---\n"
-                "*This changelog was generated using "
-                "[github-changelog-md](http://changelog.seapagan.net/) "
-                "by [Seapagan](https://github.com/seapagan)*\n",
-            )
+            f.write(rendered_changelog)
 
         rprint(self.done_str)
         rprint(
@@ -330,41 +303,39 @@ class ChangeLog:
             f"[bold]{Path.cwd() / self.options['output_file']}[/bold]\n",
         )
 
+    def _renderer(self) -> ChangelogRenderer:
+        """Create the Markdown renderer for the current changelog data."""
+        return ChangelogRenderer(
+            repo_data=getattr(
+                self,
+                "repo_data",
+                ChangelogRepository(
+                    name=self.repo_name,
+                    full_name=self.repo_name,
+                    html_url="",
+                ),
+            ),
+            repo_releases=getattr(self, "repo_releases", []),
+            pr_by_release=getattr(self, "pr_by_release", {}),
+            issue_by_release=getattr(self, "issue_by_release", {}),
+            unreleased=getattr(self, "unreleased", []),
+            unreleased_issues=getattr(self, "unreleased_issues", []),
+            release_text_cache=self.release_text_cache,
+            options=self.options,
+            settings=self.settings,
+            sections=getattr(self, "sections", SECTIONS),
+            ignored_labels=getattr(self, "ignored_labels", []),
+            prev_release=self.prev_release,
+        )
+
     def process_unreleased(
         self,
         f: TextIOWrapper,
     ) -> None:
         """Process the unreleased PRs and Issues into the changelog."""
-        if self.unreleased or self.unreleased_issues:
-            heading = self.options["next_release"] or "Unreleased"
-            text_date = (
-                datetime.datetime.now(tz=datetime.timezone.utc)
-                .date()
-                .strftime(self.settings.date_format)
-            )
-            release_date = (
-                f" ({text_date})" if self.options["next_release"] else ""
-            )
-            release_link = (
-                "tree/HEAD"
-                if not self.options["next_release"]
-                else f"releases/tag/{self.options['next_release']}"
-            )
-            f.write(
-                f"## [{heading}]({self.repo_data.html_url}/{release_link})"
-                f"{release_date}\n\n",
-            )
-
-            # show any release text that is defined for this release
-            self.show_release_text(
-                f,
-                self.options["next_release"] or "unreleased",
-            )
-
-            self.rprint_issues(f, self.unreleased_issues)
-            self.rprint_prs(f, self.unreleased)
-
-            self.prev_release = "HEAD"
+        renderer = self._renderer()
+        renderer.process_unreleased(f)
+        self.prev_release = renderer.prev_release
 
     def process_release(
         self,
@@ -372,82 +343,15 @@ class ChangeLog:
         release: Release,
     ) -> None:
         """Process a single release."""
-        if (
-            self.options["skip_releases"]
-            and release.tag_name.strip() in self.options["skip_releases"]
-        ):
-            return
-        if self.prev_release:
-            self.generate_diff_url(f, self.prev_release, release)
-
-        # show any text before this release if it exists
-        self.show_before_text(f, release)
-
-        text_date = release.created_at.date().strftime(
-            self.settings.date_format
-        )
-        f.write(
-            f"## [{release.tag_name}]({release.html_url}) ({text_date})",
-        )
-        self.check_yanked(f, release)
-
-        f.write("\n\n")
-
-        # write the release title if it is different from the tag name
-        # and it is not empty. We may need to strip any leading alpha character
-        # from the title (eg 'v' or 'V')
-        if title_unique(release):
-            f.write(f"**_{cap_first_letter(release.title.strip())}_**\n\n")
-
-        pr_list: list[PullRequestItem] = self.pr_by_release.get(release.id, [])
-        issue_list: list[IssueItem] = self.issue_by_release.get(release.id, [])
-
-        # show any release text that is defined for this release
-        self.show_release_text(f, release)
-
-        if (
-            release.tag_name
-            in self.release_text_cache.release_overrides_by_release
-        ):
-            f.write(
-                self.release_text_cache.release_overrides_by_release[
-                    release.tag_name
-                ]
-            )
-            f.write("\n")
-            return
-
-        self.rprint_issues(f, issue_list)
-        self.rprint_prs(f, pr_list)
-
-        # if no closed releases or PR's then get the release body instead
-        if not issue_list and not pr_list:
-            self.get_release_body(f, release)
+        self._renderer().process_release(f, release)
 
     def check_yanked(self, f: TextIOWrapper, release: Release) -> None:
         """Note if this release has been yanked, and the reason why."""
-        if release.tag_name in self.release_text_cache.yanked_by_release:
-            f.write(" **[`YANKED`]**\n\n")
-            f.write(
-                "**This release has been removed for the following reason and "
-                "should not be used:**\n\n"
-                f"- "
-                f"{self.release_text_cache.yanked_by_release[release.tag_name]}"
-            )
+        self._renderer().check_yanked(f, release)
 
     def show_before_text(self, f: TextIOWrapper, release: Release) -> None:
         """Shows text before this release if it exists."""
-        if (
-            release.tag_name
-            in self.release_text_cache.release_text_before_by_release
-        ):
-            f.write("---\n\n")
-            f.write(
-                self.release_text_cache.release_text_before_by_release[
-                    release.tag_name
-                ]
-            )
-            f.write("\n\n---\n\n")
+        self._renderer().show_before_text(f, release)
 
     def show_release_text(
         self,
@@ -455,39 +359,15 @@ class ChangeLog:
         release: str | Release,
     ) -> None:
         """Print the release_text if it exists."""
-        tag_name = release if isinstance(release, str) else release.tag_name
-
-        if tag_name in self.release_text_cache.release_text_by_release:
-            f.write(self.release_text_cache.release_text_by_release[tag_name])
-            f.write("\n\n")
+        self._renderer().show_release_text(f, release)
 
     def get_release_body(
         self,
         f: TextIOWrapper,
         release: Release,
     ) -> None:
-        """Read the GitHub release body.
-
-        first remove any existing diff links so we can add our
-        own. The auto-generated release notes on GitHub will
-        add a diff link to the release notes. We don't want that.
-        """
-        if release.body:
-            body_lines = release.body.split("\n")
-            for i, line in enumerate(body_lines):
-                if f"{self.repo_data.html_url}/compare/" in line:
-                    body_lines.pop(i)
-                    break
-            body = "\n".join(body_lines)
-            if body.strip() and not body.endswith("\n"):
-                body += "\n"
-            f.write(body)
-        else:
-            f.write(
-                "There were no merged pull requests or closed issues "
-                "for this release.\n\n"
-                "See the Full Changelog below for details.\n\n"
-            )
+        """Read the GitHub release body."""
+        self._renderer().get_release_body(f, release)
 
     def rprint_issues(
         self,
@@ -495,35 +375,7 @@ class ChangeLog:
         issue_list: list[IssueItem],
     ) -> None:
         """Print all the closed issues for a given release."""
-        visible_issues = self.ignore_items(list(issue_list))
-        if not visible_issues or not self.options["show_issues"]:
-            return
-
-        f.write("**Closed Issues**\n\n")
-        for issue in self.get_sorted_items(visible_issues):
-            if any(
-                label.name.lower() in self.ignored_labels
-                for label in issue.labels
-            ):
-                continue
-            escaped_title = cap_first_letter(
-                issue.title.replace("__", "\\_\\_").strip(),
-            )
-            try:
-                f.write(
-                    f"- {escaped_title} "
-                    f"([#{issue.number}]({issue.html_url})) "
-                    f"by [{issue.closed_by.login}]"
-                    f"({issue.closed_by.html_url})\n",
-                )
-            except AttributeError:
-                # this means the issue was closed by a user who has since been
-                # deleted, or it was converted to a discussion. We can't get any
-                # info on them.
-                f.write(
-                    f"- {escaped_title} ([#{issue.number}]({issue.html_url}))\n"
-                )
-        f.write("\n")
+        self._renderer().rprint_issues(f, issue_list)
 
     def generate_diff_url(
         self,
@@ -532,122 +384,25 @@ class ChangeLog:
         release_tag: Release,
     ) -> None:
         """Generate a GitHub 3-dots link to the diff between two releases."""
-        if not isinstance(prev_release, str):
-            prev_release = prev_release.tag_name
-        elif self.options["next_release"]:
-            prev_release = self.options["next_release"]
-        f.write(
-            f"[`Full Changelog`]"
-            f"({self.repo_data.html_url}/compare/"
-            f"{release_tag.tag_name}...{prev_release})",
-        )
-        if self.options["show_diff"]:
-            f.write(
-                f" | [`Diff`]({self.repo_data.html_url}/compare/"
-                f"{release_tag.tag_name}...{prev_release}.diff)",
-            )
-        if self.options["show_patch"]:
-            f.write(
-                f" | [`Patch`]({self.repo_data.html_url}/compare/"
-                f"{release_tag.tag_name}...{prev_release}.patch)",
-            )
-        f.write("\n\n")
+        self._renderer().generate_diff_url(f, prev_release, release_tag)
 
     def rprint_prs(
         self,
         f: TextIOWrapper,
         pr_list: list[PullRequestItem],
     ) -> None:
-        """Print all the PRs for a given release.
-
-        They are sorted into sections depending on the labels they have.
-        """
-        if not pr_list:
-            return
-
-        release_sections = self.get_release_sections(pr_list)
-
-        # default section for PRs that don't have any of the specific labels we
-        # have defined for section headings. This may be able to be merged with
-        # the above dict comprehension?
-
-        # find the new section title
-
-        merged_section_title = next(
-            (section[0] for section in self.sections if section[1] is None),
-            "Merged Pull Requests",
-        )
-        release_sections[merged_section_title] = [
-            pr
-            for pr in pr_list
-            if not any(
-                section_label
-                in [pr_label.name.lower() for pr_label in pr.labels]
-                for _, section_label in self.sections
-            )
-            and not any(
-                pr_label.name.lower() in self.ignored_labels
-                for pr_label in pr.labels
-            )
-        ]
-
-        for heading, prs in release_sections.items():
-            is_dependencies = heading == get_section_name("dependencies")
-            if is_dependencies and not self.options["show_depends"]:
-                continue
-
-            visible_prs = self.ignore_items(list(prs))
-
-            if visible_prs:
-                f.write(f"**{heading}**\n\n")
-                sorted_prs = self.get_sorted_items(visible_prs)
-                display_prs = (
-                    sorted_prs[: self.options["max_depends"]]
-                    if is_dependencies
-                    else sorted_prs
-                )
-                for pr in display_prs:
-                    escaped_title = cap_first_letter(
-                        pr.title.replace("__", "\\_\\_").strip(),
-                    )
-                    f.write(
-                        f"- {escaped_title} "
-                        f"([#{pr.number}]({pr.html_url})) "
-                        f"by [{pr.user.login}]({pr.user.html_url})\n",
-                    )
-                if (
-                    is_dependencies
-                    and len(sorted_prs) > self.options["max_depends"]
-                ):
-                    hidden_updates = (
-                        len(sorted_prs) - self.options["max_depends"]
-                    )
-                    f.write(
-                        f"- *and {hidden_updates} more dependency updates*\n",
-                    )
-                f.write("\n")
+        """Print all the PRs for a given release."""
+        self._renderer().rprint_prs(f, pr_list)
 
     def ignore_items(
         self, items: list[PullRequestItem | IssueItem]
     ) -> list[PullRequestItem | IssueItem]:
         """Ignore any PRs or Issues that have been marked as hidden."""
-        if not self.options["ignore_items"]:
-            return items
-        return [
-            item
-            for item in items
-            if item.number not in self.options["ignore_items"]
-            and "[no changelog]" not in item.title.lower()
-        ]
+        return self._renderer().ignore_items(items)
 
     def get_sorted_items(self, items: list[Any]) -> list[Any]:
         """Sort the PRs or Issues into the required order."""
-        if self.options["item_order"] == "newest-first":
-            return sorted(items, key=lambda x: x.number, reverse=True)
-        if self.options["item_order"] == "oldest-first":
-            return sorted(items, key=lambda x: x.number)
-        # any other value will be ignored and the default order will be used
-        return items
+        return self._renderer().get_sorted_items(items)
 
     def get_release_sections(
         self, pr_list: list[PullRequestItem]
@@ -657,19 +412,7 @@ class ChangeLog:
         This handles the PRs that have a label, we handle the PRs that don't
         have a label separately.
         """
-        return {
-            heading: [
-                pr
-                for pr in pr_list
-                if section_label
-                in [pr_label.name.lower() for pr_label in pr.labels]
-                and not any(
-                    pr_label.name.lower() in self.ignored_labels
-                    for pr_label in pr.labels
-                )
-            ]
-            for heading, section_label in self.sections
-        }
+        return self._renderer().get_release_sections(pr_list)
 
     def link_issues(self) -> dict[int, list[IssueItem]]:
         """Link Issues to their respective Release.

--- a/github_changelog_md/changelog/changelog.py
+++ b/github_changelog_md/changelog/changelog.py
@@ -336,7 +336,9 @@ class ChangeLog:
     ) -> None:
         """Process the unreleased PRs and Issues into the changelog."""
         renderer = self._renderer()
-        renderer.process_unreleased(f)
+        rendered = renderer.render_unreleased()
+        if rendered:
+            f.write(rendered)
         self.prev_release = renderer.prev_release
 
     def process_release(
@@ -345,15 +347,21 @@ class ChangeLog:
         release: Release,
     ) -> None:
         """Process a single release."""
-        self._renderer().process_release(f, release)
+        rendered = self._renderer().render_release(release)
+        if rendered:
+            f.write(rendered)
 
     def check_yanked(self, f: TextIOWrapper, release: Release) -> None:
         """Note if this release has been yanked, and the reason why."""
-        self._renderer().check_yanked(f, release)
+        rendered = self._renderer().render_yanked_notice(release)
+        if rendered:
+            f.write(rendered)
 
     def show_before_text(self, f: TextIOWrapper, release: Release) -> None:
         """Shows text before this release if it exists."""
-        self._renderer().show_before_text(f, release)
+        rendered = self._renderer().render_before_text(release)
+        if rendered:
+            f.write(rendered)
 
     def show_release_text(
         self,
@@ -361,7 +369,9 @@ class ChangeLog:
         release: str | Release,
     ) -> None:
         """Print the release_text if it exists."""
-        self._renderer().show_release_text(f, release)
+        rendered = self._renderer().render_release_text(release)
+        if rendered:
+            f.write(rendered)
 
     def get_release_body(
         self,
@@ -369,7 +379,9 @@ class ChangeLog:
         release: Release,
     ) -> None:
         """Read the GitHub release body."""
-        self._renderer().get_release_body(f, release)
+        rendered = self._renderer().render_release_body(release)
+        if rendered:
+            f.write(rendered)
 
     def rprint_issues(
         self,
@@ -377,7 +389,9 @@ class ChangeLog:
         issue_list: list[IssueItem],
     ) -> None:
         """Print all the closed issues for a given release."""
-        self._renderer().rprint_issues(f, issue_list)
+        rendered = self._renderer().render_issues(issue_list)
+        if rendered:
+            f.write(rendered)
 
     def generate_diff_url(
         self,
@@ -386,7 +400,9 @@ class ChangeLog:
         release_tag: Release,
     ) -> None:
         """Generate a GitHub 3-dots link to the diff between two releases."""
-        self._renderer().generate_diff_url(f, prev_release, release_tag)
+        rendered = self._renderer().render_diff_links(prev_release, release_tag)
+        if rendered:
+            f.write(rendered)
 
     def rprint_prs(
         self,
@@ -394,7 +410,9 @@ class ChangeLog:
         pr_list: list[PullRequestItem],
     ) -> None:
         """Print all the PRs for a given release."""
-        self._renderer().rprint_prs(f, pr_list)
+        rendered = self._renderer().render_pull_requests(pr_list)
+        if rendered:
+            f.write(rendered)
 
     def ignore_items(
         self, items: list[PullRequestItem | IssueItem]

--- a/github_changelog_md/changelog/changelog.py
+++ b/github_changelog_md/changelog/changelog.py
@@ -65,6 +65,30 @@ class ReleaseTextCache:
     release_overrides_by_release: dict[str, str] = field(default_factory=dict)
 
 
+def build_release_text_cache(settings: Settings) -> ReleaseTextCache:
+    """Build release-text lookup caches from settings."""
+    return ReleaseTextCache(
+        yanked_by_release=ChangeLog.build_release_lookup(
+            settings.yanked,
+            value_key="reason",
+        ),
+        release_text_before_by_release=ChangeLog.build_release_lookup(
+            settings.release_text_before,
+            value_key="text",
+            strip_value=True,
+        ),
+        release_text_by_release=ChangeLog.build_release_lookup(
+            settings.release_text,
+            value_key="text",
+            strip_value=True,
+        ),
+        release_overrides_by_release=ChangeLog.build_release_lookup(
+            settings.release_overrides,
+            value_key="text",
+        ),
+    )
+
+
 class ChangeLog:
     """Define the Changelog class."""
 
@@ -76,6 +100,7 @@ class ChangeLog:
         options: ChangelogOptions,
         settings: Settings,
         data_source: GitHubDataSource,
+        release_text_cache: ReleaseTextCache | None = None,
     ) -> None:
         """Initialize the class."""
         self.settings = settings
@@ -98,26 +123,7 @@ class ChangeLog:
         self.unreleased: list[PullRequestItem]
         self.unreleased_issues: list[IssueItem]
         self.contributors: list[ChangelogUser]
-        self.release_text_cache = ReleaseTextCache(
-            yanked_by_release=self.build_release_lookup(
-                self.settings.yanked,
-                value_key="reason",
-            ),
-            release_text_before_by_release=self.build_release_lookup(
-                self.settings.release_text_before,
-                value_key="text",
-                strip_value=True,
-            ),
-            release_text_by_release=self.build_release_lookup(
-                self.settings.release_text,
-                value_key="text",
-                strip_value=True,
-            ),
-            release_overrides_by_release=self.build_release_lookup(
-                self.settings.release_overrides,
-                value_key="text",
-            ),
-        )
+        self.release_text_cache = release_text_cache or ReleaseTextCache()
 
     @staticmethod
     def build_release_lookup(

--- a/github_changelog_md/changelog/changelog.py
+++ b/github_changelog_md/changelog/changelog.py
@@ -11,19 +11,18 @@ import os
 import sys
 from dataclasses import dataclass, field
 from pathlib import Path
-from typing import TYPE_CHECKING, Any, Literal, NoReturn, TypeAlias
+from typing import TYPE_CHECKING, Any, Literal, TypeAlias
 
 import typer
-from github import Auth, Github, GithubException
-from github.GitRelease import GitRelease
 from rich import print as rprint
 
 from github_changelog_md.changelog.models import (
     ChangelogIssue,
     ChangelogPullRequest,
     ChangelogRelease,
+    ChangelogRepository,
+    ChangelogUser,
 )
-from github_changelog_md.config import get_settings
 from github_changelog_md.constants import (
     CONTRIBUTORS_FILE,
     IGNORED_CONTRIBUTORS,
@@ -44,31 +43,12 @@ from github_changelog_md.helpers import (
 if TYPE_CHECKING:  # pragma: no cover
     from io import TextIOWrapper
 
-    from github.Commit import Commit
-    from github.Issue import Issue
-    from github.NamedUser import NamedUser
-    from github.PaginatedList import PaginatedList
-    from github.PullRequest import PullRequest
-    from github.Repository import Repository
+    from github_changelog_md.changelog.github_data import GitHubDataSource
+    from github_changelog_md.config.settings import Settings
 
-if TYPE_CHECKING:
-    Release: TypeAlias = GitRelease | ChangelogRelease
-    PullRequestItem: TypeAlias = PullRequest | ChangelogPullRequest
-    IssueItem: TypeAlias = Issue | ChangelogIssue
-else:
-    Release = GitRelease | ChangelogRelease
-    PullRequestItem = ChangelogPullRequest
-    IssueItem = ChangelogIssue
-
-
-def git_error(exc: GithubException) -> NoReturn:
-    """Handle a Git Exception."""
-    rprint(
-        f"\n[red]  X  Error {exc.status} while getting the "
-        f"Repo : {exc.data.get('message')}\n",
-        file=sys.stderr,
-    )
-    raise typer.Exit(ExitErrors.GIT_ERROR)
+Release: TypeAlias = ChangelogRelease
+PullRequestItem: TypeAlias = ChangelogPullRequest
+IssueItem: TypeAlias = ChangelogIssue
 
 
 @dataclass
@@ -90,20 +70,12 @@ class ChangeLog:
         self,
         repo_name: str,
         options: ChangelogOptions,
+        settings: Settings,
+        data_source: GitHubDataSource,
     ) -> None:
         """Initialize the class."""
-        self.settings = get_settings()
-
-        try:
-            self.auth = Auth.Token(self.settings.github_pat)
-            self.git = Github(auth=self.auth)
-        except AttributeError as exc:
-            rprint(
-                "\n[red]  X  Error: No GitHub PAT found in settings file\n",
-                file=sys.stderr,
-            )
-            raise typer.Exit(ExitErrors.NO_PAT) from exc
-
+        self.settings = settings
+        self.data_source = data_source
         self.repo_name: str = repo_name
         self.user: str | None = options["user_name"]
         self.options = options
@@ -111,17 +83,17 @@ class ChangeLog:
         self.sections: list[SectionHeadings]
         self.ignored_labels: list[str]
 
-        self.repo_data: Repository
+        self.repo_data: ChangelogRepository
         self.repo_releases: list[Release]
-        self.repo_prs: PaginatedList[PullRequest]
-        self.repo_issues: PaginatedList[Issue]
+        self.repo_prs: list[PullRequestItem]
+        self.repo_issues: list[IssueItem]
         self.pr_by_release: dict[int, list[PullRequestItem]]
         self.issue_by_release: dict[int, list[IssueItem]]
         self.prev_release: Release | Literal["HEAD"] | None = None
         self.filtered_repo_issues: list[IssueItem]
         self.unreleased: list[PullRequestItem]
         self.unreleased_issues: list[IssueItem]
-        self.contributors: list[NamedUser]
+        self.contributors: list[ChangelogUser]
         self.release_text_cache = ReleaseTextCache(
             yanked_by_release=self.build_release_lookup(
                 self.settings.yanked,
@@ -264,13 +236,13 @@ class ChangeLog:
             SECTIONS[:insert_index] + extend_sections + SECTIONS[insert_index:]
         )
 
-    def get_contributors(self) -> list[NamedUser]:
+    def get_contributors(self) -> list[ChangelogUser]:
         """This will get all the contributors to the repo.
 
         It will return a list of NamedUser objects, getting these from the list
         of PRs and Issues, removing any duplicates
         """
-        user_list: list[NamedUser] = []
+        user_list: list[ChangelogUser] = []
         rprint("  [green]->[/green] Getting Contributors ... ", end="")
         for pr in self.repo_prs:
             if pr.user not in user_list:
@@ -735,15 +707,14 @@ class ChangeLog:
         rprint(self.done_str)
         return issue_by_release
 
-    def get_latest_release_date(self) -> datetime.date:
+    def get_latest_release_date(self) -> datetime.datetime:
         """Return the date of the latest release."""
         try:
             last_release_date = self.repo_releases[-1].created_at
         except IndexError:
             # there have been no releases yet, so we need to get the date of
             # the first commit.
-            first_commit: Commit = self.repo_data.get_commits().reversed[0]
-            last_release_date = first_commit.commit.committer.date
+            last_release_date = self.data_source.get_first_commit_date()
         return last_release_date
 
     def link_pull_requests(self) -> dict[int, list[PullRequestItem]]:
@@ -800,57 +771,18 @@ class ChangeLog:
         )
         return filtered_repo_issues
 
-    def get_closed_issues(self) -> PaginatedList[Issue]:
+    def get_closed_issues(self) -> list[IssueItem]:
         """Get info on all the closed issues from GitHub."""
-        rprint("  [green]->[/green] Getting Closed Issues ... ", end="")
-        try:
-            repo_issues = self.repo_data.get_issues(
-                state="closed",
-                sort="created",
-            )
-        except GithubException as exc:
-            git_error(exc)
-        else:
-            rprint(f"[green]{repo_issues.totalCount} Found[/green]")
-            return repo_issues
+        return self.data_source.get_closed_issues()
 
-    def get_closed_prs(self) -> PaginatedList[PullRequest]:
+    def get_closed_prs(self) -> list[PullRequestItem]:
         """Get info on all the closed PRs from GitHub."""
-        rprint("  [green]->[/green] Getting Closed PRs ... ", end="")
-        try:
-            repo_prs = self.repo_data.get_pulls(
-                state="closed", sort="created", direction="desc"
-            )
-        except GithubException as exc:
-            git_error(exc)
-        else:
-            rprint(f"[green]{repo_prs.totalCount} Found[/green]")
-            return repo_prs
+        return self.data_source.get_closed_prs()
 
     def get_repo_releases(self) -> list[Release]:
         """Get info on all the releases from GitHub."""
-        rprint("  [green]->[/green] Getting Releases ... ", end="")
-        try:
-            repo_releases = self.repo_data.get_releases()
-        except GithubException as exc:
-            git_error(exc)
-        else:
-            rprint(f"[green]{repo_releases.totalCount} Found[/green]")
-            return list(repo_releases)
+        return self.data_source.get_repo_releases()
 
-    def get_repo_data(self) -> Repository:
+    def get_repo_data(self) -> ChangelogRepository:
         """Read the repository data from GitHub."""
-        rprint("  [green]->[/green] Getting Repository data ... ", end="")
-        try:
-            repo_user = self.user or self.git.get_user().login
-
-            repo_data = self.git.get_user(repo_user).get_repo(self.repo_name)
-        except GithubException as exc:
-            git_error(exc)
-        else:
-            rprint(self.done_str)
-            rprint(
-                "  [green]->[/green] Repository : "
-                f"[bold]{repo_data.full_name}[/bold]",
-            )
-            return repo_data
+        return self.data_source.get_repo_data(self.repo_name, self.user)

--- a/github_changelog_md/changelog/github_data.py
+++ b/github_changelog_md/changelog/github_data.py
@@ -1,0 +1,195 @@
+"""GitHub data access for changelog generation."""
+
+from __future__ import annotations
+
+import sys
+from typing import TYPE_CHECKING, NoReturn, TypeVar
+
+import typer
+from github import Auth, Github, GithubException
+from rich import print as rprint
+from rich.progress import (
+    BarColumn,
+    Progress,
+    ProgressColumn,
+    SpinnerColumn,
+    Task,
+    TaskProgressColumn,
+    TextColumn,
+    TimeElapsedColumn,
+    TimeRemainingColumn,
+)
+
+from github_changelog_md.changelog.models import (
+    ChangelogIssue,
+    ChangelogPullRequest,
+    ChangelogRelease,
+    ChangelogRepository,
+    issue_from_github,
+    pull_request_from_github,
+    release_from_github,
+    repository_from_github,
+)
+from github_changelog_md.constants import ExitErrors
+
+if TYPE_CHECKING:  # pragma: no cover
+    import datetime
+    from collections.abc import Callable, Iterable
+
+    from github.Repository import Repository
+
+GithubItem = TypeVar("GithubItem")
+ChangelogItem = TypeVar("ChangelogItem")
+
+
+class ItemCountColumn(ProgressColumn):
+    """Render item counts for known and unknown totals."""
+
+    def render(self, task: Task) -> str:
+        """Render completed item count, with total when available."""
+        completed = int(task.completed)
+        if task.total is None:
+            return str(completed)
+        return f"{completed}/{int(task.total)}"
+
+
+def git_error(exc: GithubException) -> NoReturn:
+    """Handle a Git Exception."""
+    rprint(
+        f"\n[red]  X  Error {exc.status} while getting the "
+        f"Repo : {exc.data.get('message')}\n",
+        file=sys.stderr,
+    )
+    raise typer.Exit(ExitErrors.GIT_ERROR)
+
+
+class GitHubDataSource:
+    """Fetch and adapt GitHub repository data."""
+
+    def __init__(self, github_pat: str) -> None:
+        """Initialize the GitHub client."""
+        self.auth = Auth.Token(github_pat)
+        self.git = Github(auth=self.auth)
+        self.repo_data: Repository | None = None
+
+    def get_repo_data(
+        self, repo_name: str, user: str | None
+    ) -> ChangelogRepository:
+        """Read the repository data from GitHub."""
+        rprint("  [green]->[/green] Getting Repository data ... ", end="")
+        try:
+            repo_user = user or self.git.get_user().login
+            self.repo_data = self.git.get_user(repo_user).get_repo(repo_name)
+        except GithubException as exc:
+            git_error(exc)
+        else:
+            rprint("[green]Done[/green]")
+            repo = repository_from_github(self.repo_data)
+            rprint(
+                "  [green]->[/green] Repository : "
+                f"[bold]{repo.full_name}[/bold]",
+            )
+            return repo
+
+    def get_repo_releases(self) -> list[ChangelogRelease]:
+        """Get release data from GitHub."""
+        rprint("  [green]->[/green] Getting Releases ... ", end="")
+        try:
+            repo_releases = self._repo_data.get_releases()
+        except GithubException as exc:
+            git_error(exc)
+        else:
+            rprint(f"[green]{repo_releases.totalCount} Found[/green]")
+            return self._adapt_items(
+                "Loading release details",
+                repo_releases,
+                repo_releases.totalCount,
+                release_from_github,
+            )
+
+    def get_closed_prs(self) -> list[ChangelogPullRequest]:
+        """Get closed pull requests from GitHub."""
+        rprint("  [green]->[/green] Getting Closed PRs ... ", end="")
+        try:
+            repo_prs = self._repo_data.get_pulls(
+                state="closed", sort="created", direction="desc"
+            )
+        except GithubException as exc:
+            git_error(exc)
+        else:
+            rprint(f"[green]{repo_prs.totalCount} Found[/green]")
+            return self._adapt_items(
+                "Loading PR details",
+                repo_prs,
+                repo_prs.totalCount,
+                pull_request_from_github,
+            )
+
+    def get_closed_issues(self) -> list[ChangelogIssue]:
+        """Get closed issues from GitHub."""
+        rprint(
+            "  [green]->[/green] Getting Closed Issue Candidates ... ",
+        )
+        try:
+            repo_issues = self._repo_data.get_issues(
+                state="closed",
+                sort="created",
+            )
+        except GithubException as exc:
+            git_error(exc)
+        else:
+            return self._adapt_items(
+                "Loading issue candidates",
+                repo_issues,
+                0,
+                issue_from_github,
+            )
+
+    def get_first_commit_date(self) -> datetime.datetime:
+        """Return the first commit date for repositories without releases."""
+        first_commit = self._repo_data.get_commits().reversed[0]
+        return first_commit.commit.committer.date
+
+    @property
+    def _repo_data(self) -> Repository:
+        if self.repo_data is None:
+            msg = "Repository data has not been loaded"
+            raise RuntimeError(msg)
+        return self.repo_data
+
+    def _adapt_items(
+        self,
+        description: str,
+        items: Iterable[GithubItem],
+        total: int,
+        adapter: Callable[[GithubItem], ChangelogItem],
+    ) -> list[ChangelogItem]:
+        """Adapt GitHub items while showing visible progress."""
+        adapted: list[ChangelogItem] = []
+        progress_total = total if total > 0 else None
+        columns: tuple[str | ProgressColumn, ...]
+        if progress_total is None:
+            columns = (
+                SpinnerColumn(),
+                TextColumn("  [green]->[/green] {task.description}"),
+                ItemCountColumn(),
+                TimeElapsedColumn(),
+            )
+        else:
+            columns = (
+                TextColumn("  [green]->[/green] {task.description}"),
+                BarColumn(),
+                TaskProgressColumn(),
+                ItemCountColumn(),
+                TimeRemainingColumn(),
+            )
+        with Progress(
+            *columns,
+            redirect_stdout=False,
+            redirect_stderr=False,
+        ) as progress:
+            task = progress.add_task(description, total=progress_total)
+            for item in items:
+                adapted.append(adapter(item))
+                progress.advance(task)
+        return adapted

--- a/github_changelog_md/changelog/github_data.py
+++ b/github_changelog_md/changelog/github_data.py
@@ -66,11 +66,16 @@ def git_error(exc: GithubException) -> NoReturn:
 class GitHubDataSource:
     """Fetch and adapt GitHub repository data."""
 
-    def __init__(self, github_pat: str) -> None:
-        """Initialize the GitHub client."""
-        self.auth = Auth.Token(github_pat)
-        self.git = Github(auth=self.auth)
+    def __init__(self, git: Github) -> None:
+        """Initialize the data source with a GitHub client."""
+        self.git = git
         self.repo_data: Repository | None = None
+
+    @classmethod
+    def from_token(cls, github_pat: str) -> GitHubDataSource:
+        """Create a data source from a GitHub personal access token."""
+        auth = Auth.Token(github_pat)
+        return cls(Github(auth=auth))
 
     def get_repo_data(
         self, repo_name: str, user: str | None

--- a/github_changelog_md/changelog/models.py
+++ b/github_changelog_md/changelog/models.py
@@ -1,0 +1,139 @@
+"""Internal changelog domain models."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:  # pragma: no cover
+    import datetime
+
+    from github.GitRelease import GitRelease
+    from github.Issue import Issue as GithubIssue
+    from github.Label import Label as GithubLabel
+    from github.NamedUser import NamedUser
+    from github.PullRequest import PullRequest as GithubPullRequest
+
+
+@dataclass(frozen=True, slots=True)
+class ChangelogUser:
+    """User details needed while generating a changelog."""
+
+    login: str
+    html_url: str
+    name: str | None = None
+
+
+@dataclass(frozen=True, slots=True)
+class ChangelogLabel:
+    """Label details needed while generating a changelog."""
+
+    name: str
+
+
+@dataclass(frozen=True, slots=True)
+class ChangelogRelease:
+    """Release details needed while generating a changelog."""
+
+    id: int
+    tag_name: str
+    title: str
+    html_url: str
+    created_at: datetime.datetime
+    body: str | None = None
+
+
+@dataclass(frozen=True, slots=True)
+class ChangelogPullRequest:
+    """Pull request details needed while generating a changelog."""
+
+    id: int
+    number: int
+    title: str
+    html_url: str
+    user: ChangelogUser
+    labels: list[ChangelogLabel]
+    merged_at: datetime.datetime | None
+
+
+@dataclass(frozen=True, slots=True)
+class ChangelogIssue:
+    """Issue details needed while generating a changelog."""
+
+    id: int
+    number: int
+    title: str
+    html_url: str
+    user: ChangelogUser
+    labels: list[ChangelogLabel]
+    closed_at: datetime.datetime | None
+    closed_by: ChangelogUser | None
+    pull_request: object | None = None
+
+
+def user_from_github(user: NamedUser | None) -> ChangelogUser | None:
+    """Convert a PyGithub user to an internal changelog user."""
+    if user is None:
+        return None
+    return ChangelogUser(
+        login=user.login,
+        html_url=user.html_url,
+        name=user.name,
+    )
+
+
+def label_from_github(label: GithubLabel) -> ChangelogLabel:
+    """Convert a PyGithub label to an internal changelog label."""
+    return ChangelogLabel(name=label.name)
+
+
+def release_from_github(release: GitRelease) -> ChangelogRelease:
+    """Convert a PyGithub release to an internal changelog release."""
+    return ChangelogRelease(
+        id=release.id,
+        tag_name=release.tag_name,
+        title=release.title,
+        html_url=release.html_url,
+        created_at=release.created_at,
+        body=release.body,
+    )
+
+
+def pull_request_from_github(
+    pull_request: GithubPullRequest,
+) -> ChangelogPullRequest:
+    """Convert a PyGithub pull request to an internal changelog PR."""
+    user = user_from_github(pull_request.user)
+    if user is None:
+        msg = "Pull request user cannot be None"
+        raise ValueError(msg)
+
+    return ChangelogPullRequest(
+        id=pull_request.id,
+        number=pull_request.number,
+        title=pull_request.title,
+        html_url=pull_request.html_url,
+        user=user,
+        labels=[label_from_github(label) for label in pull_request.labels],
+        merged_at=pull_request.merged_at,
+    )
+
+
+def issue_from_github(issue: GithubIssue) -> ChangelogIssue:
+    """Convert a PyGithub issue to an internal changelog issue."""
+    user = user_from_github(issue.user)
+    if user is None:
+        msg = "Issue user cannot be None"
+        raise ValueError(msg)
+
+    return ChangelogIssue(
+        id=issue.id,
+        number=issue.number,
+        title=issue.title,
+        html_url=issue.html_url,
+        user=user,
+        labels=[label_from_github(label) for label in issue.labels],
+        closed_at=issue.closed_at,
+        closed_by=user_from_github(issue.closed_by),
+        pull_request=issue.pull_request,
+    )

--- a/github_changelog_md/changelog/models.py
+++ b/github_changelog_md/changelog/models.py
@@ -13,6 +13,7 @@ if TYPE_CHECKING:  # pragma: no cover
     from github.Label import Label as GithubLabel
     from github.NamedUser import NamedUser
     from github.PullRequest import PullRequest as GithubPullRequest
+    from github.Repository import Repository
 
 
 @dataclass(frozen=True, slots=True)
@@ -29,6 +30,15 @@ class ChangelogLabel:
     """Label details needed while generating a changelog."""
 
     name: str
+
+
+@dataclass(frozen=True, slots=True)
+class ChangelogRepository:
+    """Repository details needed while generating a changelog."""
+
+    name: str
+    full_name: str
+    html_url: str
 
 
 @dataclass(frozen=True, slots=True)
@@ -78,13 +88,21 @@ def user_from_github(user: NamedUser | None) -> ChangelogUser | None:
     return ChangelogUser(
         login=user.login,
         html_url=user.html_url,
-        name=user.name,
     )
 
 
 def label_from_github(label: GithubLabel) -> ChangelogLabel:
     """Convert a PyGithub label to an internal changelog label."""
     return ChangelogLabel(name=label.name)
+
+
+def repository_from_github(repository: Repository) -> ChangelogRepository:
+    """Convert a PyGithub repository to an internal changelog repository."""
+    return ChangelogRepository(
+        name=repository.name,
+        full_name=repository.full_name,
+        html_url=repository.html_url,
+    )
 
 
 def release_from_github(release: GitRelease) -> ChangelogRelease:

--- a/github_changelog_md/changelog/renderer.py
+++ b/github_changelog_md/changelog/renderer.py
@@ -50,7 +50,8 @@ class ChangelogRenderer:
         output = ["# Changelog\n\n"]
 
         if self.settings.intro_text:
-            output.append(f"{self.settings.intro_text}\n\n")
+            intro_text = self.settings.intro_text.rstrip("\n")
+            output.append(f"{intro_text}\n\n")
 
         if not self.options["show_depends"]:
             output.append(
@@ -145,12 +146,12 @@ class ChangelogRenderer:
             release.tag_name
             in self.release_text_cache.release_overrides_by_release
         ):
-            output.append(
+            override_text = (
                 self.release_text_cache.release_overrides_by_release[
                     release.tag_name
                 ]
             )
-            output.append("\n")
+            output.append(f"{override_text}\n\n")
             return "".join(output)
 
         output.append(self.render_issues(issue_list))

--- a/github_changelog_md/changelog/renderer.py
+++ b/github_changelog_md/changelog/renderer.py
@@ -4,7 +4,6 @@ from __future__ import annotations
 
 import datetime
 from dataclasses import dataclass
-from io import StringIO
 from typing import TYPE_CHECKING, Any, Literal
 
 from github_changelog_md.changelog.models import (
@@ -20,8 +19,6 @@ from github_changelog_md.helpers import (
 )
 
 if TYPE_CHECKING:  # pragma: no cover
-    from io import TextIOWrapper
-
     from github_changelog_md.changelog.changelog import ReleaseTextCache
     from github_changelog_md.config.settings import Settings
     from github_changelog_md.constants import ChangelogOptions, SectionHeadings
@@ -50,14 +47,13 @@ class ChangelogRenderer:
 
     def render(self) -> str:
         """Render the complete changelog Markdown."""
-        output = StringIO()
-        output.write("# Changelog\n\n")
+        output = ["# Changelog\n\n"]
 
         if self.settings.intro_text:
-            output.write(f"{self.settings.intro_text}\n\n")
+            output.append(f"{self.settings.intro_text}\n\n")
 
         if not self.options["show_depends"]:
-            output.write(
+            output.append(
                 "*Dependency updates are excluded from this changelog, "
                 "check each `Full Changelog` for details.*\n\n "
             )
@@ -65,152 +61,146 @@ class ChangelogRenderer:
         self.prev_release = None
 
         if self.options["show_unreleased"]:
-            self.process_unreleased(output)
+            output.append(self.render_unreleased())
 
         for release in self.repo_releases:
-            self.process_release(output, release)
+            output.append(self.render_release(release))
             self.prev_release = release
 
-        output.write(
+        output.append(
             "---\n"
             "*This changelog was generated using "
             "[github-changelog-md](http://changelog.seapagan.net/) "
             "by [Seapagan](https://github.com/seapagan)*\n",
         )
-        return output.getvalue()
+        return "".join(output)
 
-    def process_unreleased(self, output: TextIOWrapper | StringIO) -> None:
+    def render_unreleased(self) -> str:
         """Process the unreleased PRs and Issues into the changelog."""
-        if self.unreleased or self.unreleased_issues:
-            heading = self.options["next_release"] or "Unreleased"
-            text_date = (
-                datetime.datetime.now(tz=datetime.timezone.utc)
-                .date()
-                .strftime(self.settings.date_format)
-            )
-            release_date = (
-                f" ({text_date})" if self.options["next_release"] else ""
-            )
-            release_link = (
-                "tree/HEAD"
-                if not self.options["next_release"]
-                else f"releases/tag/{self.options['next_release']}"
-            )
-            output.write(
-                f"## [{heading}]({self.repo_data.html_url}/{release_link})"
-                f"{release_date}\n\n",
-            )
+        if not self.unreleased and not self.unreleased_issues:
+            return ""
 
-            self.show_release_text(
-                output,
-                self.options["next_release"] or "unreleased",
-            )
+        heading = self.options["next_release"] or "Unreleased"
+        text_date = (
+            datetime.datetime.now(tz=datetime.timezone.utc)
+            .date()
+            .strftime(self.settings.date_format)
+        )
+        release_date = f" ({text_date})" if self.options["next_release"] else ""
+        release_link = (
+            "tree/HEAD"
+            if not self.options["next_release"]
+            else f"releases/tag/{self.options['next_release']}"
+        )
+        self.prev_release = "HEAD"
+        release_text = self.render_release_text(
+            self.options["next_release"] or "unreleased"
+        )
+        return (
+            f"## [{heading}]({self.repo_data.html_url}/{release_link})"
+            f"{release_date}\n\n"
+            f"{release_text}"
+            f"{self.render_issues(self.unreleased_issues)}"
+            f"{self.render_pull_requests(self.unreleased)}"
+        )
 
-            self.rprint_issues(output, self.unreleased_issues)
-            self.rprint_prs(output, self.unreleased)
-
-            self.prev_release = "HEAD"
-
-    def process_release(
+    def render_release(
         self,
-        output: TextIOWrapper | StringIO,
         release: Release,
-    ) -> None:
+    ) -> str:
         """Process a single release."""
         if (
             self.options["skip_releases"]
             and release.tag_name.strip() in self.options["skip_releases"]
         ):
-            return
-        if self.prev_release:
-            self.generate_diff_url(output, self.prev_release, release)
+            return ""
 
-        self.show_before_text(output, release)
+        output: list[str] = []
+        if self.prev_release:
+            output.append(self.render_diff_links(self.prev_release, release))
+
+        output.append(self.render_before_text(release))
 
         text_date = release.created_at.date().strftime(
             self.settings.date_format
         )
-        output.write(
+        output.append(
             f"## [{release.tag_name}]({release.html_url}) ({text_date})",
         )
-        self.check_yanked(output, release)
+        output.append(self.render_yanked_notice(release))
 
-        output.write("\n\n")
+        output.append("\n\n")
 
         if title_unique(release):
-            output.write(f"**_{cap_first_letter(release.title.strip())}_**\n\n")
+            output.append(
+                f"**_{cap_first_letter(release.title.strip())}_**\n\n"
+            )
 
         pr_list: list[PullRequestItem] = self.pr_by_release.get(release.id, [])
         issue_list: list[IssueItem] = self.issue_by_release.get(release.id, [])
 
-        self.show_release_text(output, release)
+        output.append(self.render_release_text(release))
 
         if (
             release.tag_name
             in self.release_text_cache.release_overrides_by_release
         ):
-            output.write(
+            output.append(
                 self.release_text_cache.release_overrides_by_release[
                     release.tag_name
                 ]
             )
-            output.write("\n")
-            return
+            output.append("\n")
+            return "".join(output)
 
-        self.rprint_issues(output, issue_list)
-        self.rprint_prs(output, pr_list)
+        output.append(self.render_issues(issue_list))
+        output.append(self.render_pull_requests(pr_list))
 
         if not issue_list and not pr_list:
-            self.get_release_body(output, release)
+            output.append(self.render_release_body(release))
 
-    def check_yanked(
-        self, output: TextIOWrapper | StringIO, release: Release
-    ) -> None:
+        return "".join(output)
+
+    def render_yanked_notice(self, release: Release) -> str:
         """Note if this release has been yanked, and the reason why."""
-        if release.tag_name in self.release_text_cache.yanked_by_release:
-            output.write(" **[`YANKED`]**\n\n")
-            output.write(
-                "**This release has been removed for the following reason and "
-                "should not be used:**\n\n"
-                f"- "
-                f"{self.release_text_cache.yanked_by_release[release.tag_name]}"
-            )
+        if release.tag_name not in self.release_text_cache.yanked_by_release:
+            return ""
+        return (
+            " **[`YANKED`]**\n\n"
+            "**This release has been removed for the following reason and "
+            "should not be used:**\n\n"
+            f"- {self.release_text_cache.yanked_by_release[release.tag_name]}"
+        )
 
-    def show_before_text(
-        self, output: TextIOWrapper | StringIO, release: Release
-    ) -> None:
+    def render_before_text(self, release: Release) -> str:
         """Shows text before this release if it exists."""
         if (
             release.tag_name
-            in self.release_text_cache.release_text_before_by_release
+            not in self.release_text_cache.release_text_before_by_release
         ):
-            output.write("---\n\n")
-            output.write(
-                self.release_text_cache.release_text_before_by_release[
-                    release.tag_name
-                ]
-            )
-            output.write("\n\n---\n\n")
+            return ""
+        return (
+            "---\n\n"
+            f"{self.release_text_cache.release_text_before_by_release[release.tag_name]}"
+            "\n\n---\n\n"
+        )
 
-    def show_release_text(
+    def render_release_text(
         self,
-        output: TextIOWrapper | StringIO,
         release: str | Release,
-    ) -> None:
+    ) -> str:
         """Print the release_text if it exists."""
         tag_name = release if isinstance(release, str) else release.tag_name
 
-        if tag_name in self.release_text_cache.release_text_by_release:
-            output.write(
-                self.release_text_cache.release_text_by_release[tag_name]
-            )
-            output.write("\n\n")
+        if tag_name not in self.release_text_cache.release_text_by_release:
+            return ""
+        release_text = self.release_text_cache.release_text_by_release[tag_name]
+        return f"{release_text}\n\n"
 
-    def get_release_body(
+    def render_release_body(
         self,
-        output: TextIOWrapper | StringIO,
         release: Release,
-    ) -> None:
+    ) -> str:
         """Render fallback release body text."""
         if release.body:
             body_lines = release.body.split("\n")
@@ -221,25 +211,23 @@ class ChangelogRenderer:
             body = "\n".join(body_lines)
             if body.strip() and not body.endswith("\n"):
                 body += "\n"
-            output.write(body)
-        else:
-            output.write(
-                "There were no merged pull requests or closed issues "
-                "for this release.\n\n"
-                "See the Full Changelog below for details.\n\n"
-            )
+            return body
+        return (
+            "There were no merged pull requests or closed issues "
+            "for this release.\n\n"
+            "See the Full Changelog below for details.\n\n"
+        )
 
-    def rprint_issues(
+    def render_issues(
         self,
-        output: TextIOWrapper | StringIO,
         issue_list: list[IssueItem],
-    ) -> None:
+    ) -> str:
         """Print all the closed issues for a given release."""
         visible_issues = self.ignore_items(list(issue_list))
         if not visible_issues or not self.options["show_issues"]:
-            return
+            return ""
 
-        output.write("**Closed Issues**\n\n")
+        output = ["**Closed Issues**\n\n"]
         for issue in self.get_sorted_items(visible_issues):
             if any(
                 label.name.lower() in self.ignored_labels
@@ -250,54 +238,54 @@ class ChangelogRenderer:
                 issue.title.replace("__", "\\_\\_").strip(),
             )
             try:
-                output.write(
+                output.append(
                     f"- {escaped_title} "
                     f"([#{issue.number}]({issue.html_url})) "
                     f"by [{issue.closed_by.login}]"
                     f"({issue.closed_by.html_url})\n",
                 )
             except AttributeError:
-                output.write(
+                output.append(
                     f"- {escaped_title} ([#{issue.number}]({issue.html_url}))\n"
                 )
-        output.write("\n")
+        output.append("\n")
+        return "".join(output)
 
-    def generate_diff_url(
+    def render_diff_links(
         self,
-        output: TextIOWrapper | StringIO,
         prev_release: Release | str,
         release_tag: Release,
-    ) -> None:
+    ) -> str:
         """Generate a GitHub 3-dots link to the diff between two releases."""
         if not isinstance(prev_release, str):
             prev_release = prev_release.tag_name
         elif self.options["next_release"]:
             prev_release = self.options["next_release"]
-        output.write(
+        output = [
             f"[`Full Changelog`]"
             f"({self.repo_data.html_url}/compare/"
-            f"{release_tag.tag_name}...{prev_release})",
-        )
+            f"{release_tag.tag_name}...{prev_release})"
+        ]
         if self.options["show_diff"]:
-            output.write(
+            output.append(
                 f" | [`Diff`]({self.repo_data.html_url}/compare/"
                 f"{release_tag.tag_name}...{prev_release}.diff)",
             )
         if self.options["show_patch"]:
-            output.write(
+            output.append(
                 f" | [`Patch`]({self.repo_data.html_url}/compare/"
                 f"{release_tag.tag_name}...{prev_release}.patch)",
             )
-        output.write("\n\n")
+        output.append("\n\n")
+        return "".join(output)
 
-    def rprint_prs(
+    def render_pull_requests(
         self,
-        output: TextIOWrapper | StringIO,
         pr_list: list[PullRequestItem],
-    ) -> None:
+    ) -> str:
         """Print all the PRs for a given release."""
         if not pr_list:
-            return
+            return ""
 
         release_sections = self.get_release_sections(pr_list)
         merged_section_title = next(
@@ -318,6 +306,7 @@ class ChangelogRenderer:
             )
         ]
 
+        output: list[str] = []
         for heading, prs in release_sections.items():
             is_dependencies = heading == get_section_name("dependencies")
             if is_dependencies and not self.options["show_depends"]:
@@ -326,7 +315,7 @@ class ChangelogRenderer:
             visible_prs = self.ignore_items(list(prs))
 
             if visible_prs:
-                output.write(f"**{heading}**\n\n")
+                output.append(f"**{heading}**\n\n")
                 sorted_prs = self.get_sorted_items(visible_prs)
                 display_prs = (
                     sorted_prs[: self.options["max_depends"]]
@@ -337,7 +326,7 @@ class ChangelogRenderer:
                     escaped_title = cap_first_letter(
                         pr.title.replace("__", "\\_\\_").strip(),
                     )
-                    output.write(
+                    output.append(
                         f"- {escaped_title} "
                         f"([#{pr.number}]({pr.html_url})) "
                         f"by [{pr.user.login}]({pr.user.html_url})\n",
@@ -349,10 +338,11 @@ class ChangelogRenderer:
                     hidden_updates = (
                         len(sorted_prs) - self.options["max_depends"]
                     )
-                    output.write(
+                    output.append(
                         f"- *and {hidden_updates} more dependency updates*\n",
                     )
-                output.write("\n")
+                output.append("\n")
+        return "".join(output)
 
     def ignore_items(
         self, items: list[PullRequestItem | IssueItem]

--- a/github_changelog_md/changelog/renderer.py
+++ b/github_changelog_md/changelog/renderer.py
@@ -373,7 +373,8 @@ class ChangelogRenderer:
             return sorted(items, key=lambda x: x.number, reverse=True)
         if self.options["item_order"] == "oldest-first":
             return sorted(items, key=lambda x: x.number)
-        return items
+        msg = f"Unknown item order: {self.options['item_order']}"
+        raise ValueError(msg)
 
     def get_release_sections(
         self, pr_list: list[PullRequestItem]

--- a/github_changelog_md/changelog/renderer.py
+++ b/github_changelog_md/changelog/renderer.py
@@ -1,0 +1,394 @@
+"""Markdown rendering for changelog generation."""
+
+from __future__ import annotations
+
+import datetime
+from dataclasses import dataclass
+from io import StringIO
+from typing import TYPE_CHECKING, Any, Literal
+
+from github_changelog_md.changelog.models import (
+    ChangelogIssue,
+    ChangelogPullRequest,
+    ChangelogRelease,
+    ChangelogRepository,
+)
+from github_changelog_md.helpers import (
+    cap_first_letter,
+    get_section_name,
+    title_unique,
+)
+
+if TYPE_CHECKING:  # pragma: no cover
+    from io import TextIOWrapper
+
+    from github_changelog_md.changelog.changelog import ReleaseTextCache
+    from github_changelog_md.config.settings import Settings
+    from github_changelog_md.constants import ChangelogOptions, SectionHeadings
+
+Release = ChangelogRelease
+PullRequestItem = ChangelogPullRequest
+IssueItem = ChangelogIssue
+
+
+@dataclass(slots=True)
+class ChangelogRenderer:
+    """Render changelog data to Markdown."""
+
+    repo_data: ChangelogRepository
+    repo_releases: list[Release]
+    pr_by_release: dict[int, list[PullRequestItem]]
+    issue_by_release: dict[int, list[IssueItem]]
+    unreleased: list[PullRequestItem]
+    unreleased_issues: list[IssueItem]
+    release_text_cache: ReleaseTextCache
+    options: ChangelogOptions
+    settings: Settings
+    sections: list[SectionHeadings]
+    ignored_labels: list[str]
+    prev_release: Release | Literal["HEAD"] | None = None
+
+    def render(self) -> str:
+        """Render the complete changelog Markdown."""
+        output = StringIO()
+        output.write("# Changelog\n\n")
+
+        if self.settings.intro_text:
+            output.write(f"{self.settings.intro_text}\n\n")
+
+        if not self.options["show_depends"]:
+            output.write(
+                "*Dependency updates are excluded from this changelog, "
+                "check each `Full Changelog` for details.*\n\n "
+            )
+
+        self.prev_release = None
+
+        if self.options["show_unreleased"]:
+            self.process_unreleased(output)
+
+        for release in self.repo_releases:
+            self.process_release(output, release)
+            self.prev_release = release
+
+        output.write(
+            "---\n"
+            "*This changelog was generated using "
+            "[github-changelog-md](http://changelog.seapagan.net/) "
+            "by [Seapagan](https://github.com/seapagan)*\n",
+        )
+        return output.getvalue()
+
+    def process_unreleased(self, output: TextIOWrapper | StringIO) -> None:
+        """Process the unreleased PRs and Issues into the changelog."""
+        if self.unreleased or self.unreleased_issues:
+            heading = self.options["next_release"] or "Unreleased"
+            text_date = (
+                datetime.datetime.now(tz=datetime.timezone.utc)
+                .date()
+                .strftime(self.settings.date_format)
+            )
+            release_date = (
+                f" ({text_date})" if self.options["next_release"] else ""
+            )
+            release_link = (
+                "tree/HEAD"
+                if not self.options["next_release"]
+                else f"releases/tag/{self.options['next_release']}"
+            )
+            output.write(
+                f"## [{heading}]({self.repo_data.html_url}/{release_link})"
+                f"{release_date}\n\n",
+            )
+
+            self.show_release_text(
+                output,
+                self.options["next_release"] or "unreleased",
+            )
+
+            self.rprint_issues(output, self.unreleased_issues)
+            self.rprint_prs(output, self.unreleased)
+
+            self.prev_release = "HEAD"
+
+    def process_release(
+        self,
+        output: TextIOWrapper | StringIO,
+        release: Release,
+    ) -> None:
+        """Process a single release."""
+        if (
+            self.options["skip_releases"]
+            and release.tag_name.strip() in self.options["skip_releases"]
+        ):
+            return
+        if self.prev_release:
+            self.generate_diff_url(output, self.prev_release, release)
+
+        self.show_before_text(output, release)
+
+        text_date = release.created_at.date().strftime(
+            self.settings.date_format
+        )
+        output.write(
+            f"## [{release.tag_name}]({release.html_url}) ({text_date})",
+        )
+        self.check_yanked(output, release)
+
+        output.write("\n\n")
+
+        if title_unique(release):
+            output.write(f"**_{cap_first_letter(release.title.strip())}_**\n\n")
+
+        pr_list: list[PullRequestItem] = self.pr_by_release.get(release.id, [])
+        issue_list: list[IssueItem] = self.issue_by_release.get(release.id, [])
+
+        self.show_release_text(output, release)
+
+        if (
+            release.tag_name
+            in self.release_text_cache.release_overrides_by_release
+        ):
+            output.write(
+                self.release_text_cache.release_overrides_by_release[
+                    release.tag_name
+                ]
+            )
+            output.write("\n")
+            return
+
+        self.rprint_issues(output, issue_list)
+        self.rprint_prs(output, pr_list)
+
+        if not issue_list and not pr_list:
+            self.get_release_body(output, release)
+
+    def check_yanked(
+        self, output: TextIOWrapper | StringIO, release: Release
+    ) -> None:
+        """Note if this release has been yanked, and the reason why."""
+        if release.tag_name in self.release_text_cache.yanked_by_release:
+            output.write(" **[`YANKED`]**\n\n")
+            output.write(
+                "**This release has been removed for the following reason and "
+                "should not be used:**\n\n"
+                f"- "
+                f"{self.release_text_cache.yanked_by_release[release.tag_name]}"
+            )
+
+    def show_before_text(
+        self, output: TextIOWrapper | StringIO, release: Release
+    ) -> None:
+        """Shows text before this release if it exists."""
+        if (
+            release.tag_name
+            in self.release_text_cache.release_text_before_by_release
+        ):
+            output.write("---\n\n")
+            output.write(
+                self.release_text_cache.release_text_before_by_release[
+                    release.tag_name
+                ]
+            )
+            output.write("\n\n---\n\n")
+
+    def show_release_text(
+        self,
+        output: TextIOWrapper | StringIO,
+        release: str | Release,
+    ) -> None:
+        """Print the release_text if it exists."""
+        tag_name = release if isinstance(release, str) else release.tag_name
+
+        if tag_name in self.release_text_cache.release_text_by_release:
+            output.write(
+                self.release_text_cache.release_text_by_release[tag_name]
+            )
+            output.write("\n\n")
+
+    def get_release_body(
+        self,
+        output: TextIOWrapper | StringIO,
+        release: Release,
+    ) -> None:
+        """Render fallback release body text."""
+        if release.body:
+            body_lines = release.body.split("\n")
+            for i, line in enumerate(body_lines):
+                if f"{self.repo_data.html_url}/compare/" in line:
+                    body_lines.pop(i)
+                    break
+            body = "\n".join(body_lines)
+            if body.strip() and not body.endswith("\n"):
+                body += "\n"
+            output.write(body)
+        else:
+            output.write(
+                "There were no merged pull requests or closed issues "
+                "for this release.\n\n"
+                "See the Full Changelog below for details.\n\n"
+            )
+
+    def rprint_issues(
+        self,
+        output: TextIOWrapper | StringIO,
+        issue_list: list[IssueItem],
+    ) -> None:
+        """Print all the closed issues for a given release."""
+        visible_issues = self.ignore_items(list(issue_list))
+        if not visible_issues or not self.options["show_issues"]:
+            return
+
+        output.write("**Closed Issues**\n\n")
+        for issue in self.get_sorted_items(visible_issues):
+            if any(
+                label.name.lower() in self.ignored_labels
+                for label in issue.labels
+            ):
+                continue
+            escaped_title = cap_first_letter(
+                issue.title.replace("__", "\\_\\_").strip(),
+            )
+            try:
+                output.write(
+                    f"- {escaped_title} "
+                    f"([#{issue.number}]({issue.html_url})) "
+                    f"by [{issue.closed_by.login}]"
+                    f"({issue.closed_by.html_url})\n",
+                )
+            except AttributeError:
+                output.write(
+                    f"- {escaped_title} ([#{issue.number}]({issue.html_url}))\n"
+                )
+        output.write("\n")
+
+    def generate_diff_url(
+        self,
+        output: TextIOWrapper | StringIO,
+        prev_release: Release | str,
+        release_tag: Release,
+    ) -> None:
+        """Generate a GitHub 3-dots link to the diff between two releases."""
+        if not isinstance(prev_release, str):
+            prev_release = prev_release.tag_name
+        elif self.options["next_release"]:
+            prev_release = self.options["next_release"]
+        output.write(
+            f"[`Full Changelog`]"
+            f"({self.repo_data.html_url}/compare/"
+            f"{release_tag.tag_name}...{prev_release})",
+        )
+        if self.options["show_diff"]:
+            output.write(
+                f" | [`Diff`]({self.repo_data.html_url}/compare/"
+                f"{release_tag.tag_name}...{prev_release}.diff)",
+            )
+        if self.options["show_patch"]:
+            output.write(
+                f" | [`Patch`]({self.repo_data.html_url}/compare/"
+                f"{release_tag.tag_name}...{prev_release}.patch)",
+            )
+        output.write("\n\n")
+
+    def rprint_prs(
+        self,
+        output: TextIOWrapper | StringIO,
+        pr_list: list[PullRequestItem],
+    ) -> None:
+        """Print all the PRs for a given release."""
+        if not pr_list:
+            return
+
+        release_sections = self.get_release_sections(pr_list)
+        merged_section_title = next(
+            (section[0] for section in self.sections if section[1] is None),
+            "Merged Pull Requests",
+        )
+        release_sections[merged_section_title] = [
+            pr
+            for pr in pr_list
+            if not any(
+                section_label
+                in [pr_label.name.lower() for pr_label in pr.labels]
+                for _, section_label in self.sections
+            )
+            and not any(
+                pr_label.name.lower() in self.ignored_labels
+                for pr_label in pr.labels
+            )
+        ]
+
+        for heading, prs in release_sections.items():
+            is_dependencies = heading == get_section_name("dependencies")
+            if is_dependencies and not self.options["show_depends"]:
+                continue
+
+            visible_prs = self.ignore_items(list(prs))
+
+            if visible_prs:
+                output.write(f"**{heading}**\n\n")
+                sorted_prs = self.get_sorted_items(visible_prs)
+                display_prs = (
+                    sorted_prs[: self.options["max_depends"]]
+                    if is_dependencies
+                    else sorted_prs
+                )
+                for pr in display_prs:
+                    escaped_title = cap_first_letter(
+                        pr.title.replace("__", "\\_\\_").strip(),
+                    )
+                    output.write(
+                        f"- {escaped_title} "
+                        f"([#{pr.number}]({pr.html_url})) "
+                        f"by [{pr.user.login}]({pr.user.html_url})\n",
+                    )
+                if (
+                    is_dependencies
+                    and len(sorted_prs) > self.options["max_depends"]
+                ):
+                    hidden_updates = (
+                        len(sorted_prs) - self.options["max_depends"]
+                    )
+                    output.write(
+                        f"- *and {hidden_updates} more dependency updates*\n",
+                    )
+                output.write("\n")
+
+    def ignore_items(
+        self, items: list[PullRequestItem | IssueItem]
+    ) -> list[PullRequestItem | IssueItem]:
+        """Ignore any PRs or Issues that have been marked as hidden."""
+        if not self.options["ignore_items"]:
+            return items
+        return [
+            item
+            for item in items
+            if item.number not in self.options["ignore_items"]
+            and "[no changelog]" not in item.title.lower()
+        ]
+
+    def get_sorted_items(self, items: list[Any]) -> list[Any]:
+        """Sort the PRs or Issues into the required order."""
+        if self.options["item_order"] == "newest-first":
+            return sorted(items, key=lambda x: x.number, reverse=True)
+        if self.options["item_order"] == "oldest-first":
+            return sorted(items, key=lambda x: x.number)
+        return items
+
+    def get_release_sections(
+        self, pr_list: list[PullRequestItem]
+    ) -> dict[str, list[PullRequestItem]]:
+        """Return a dictionary of PRs sorted into sections."""
+        return {
+            heading: [
+                pr
+                for pr in pr_list
+                if section_label
+                in [pr_label.name.lower() for pr_label in pr.labels]
+                and not any(
+                    pr_label.name.lower() in self.ignored_labels
+                    for pr_label in pr.labels
+                )
+            ]
+            for heading, section_label in self.sections
+        }

--- a/github_changelog_md/config/settings.py
+++ b/github_changelog_md/config/settings.py
@@ -71,9 +71,9 @@ def get_pat_input() -> str:
     return user_pat
 
 
-# not too happy with this method of doing it. Ideally I need to modify the
-# Settings class to allow for a default value of PAT to be set though the
-# constructor, then enable autocreate again.
+# Missing config files are created manually so the prompted PAT can be written
+# before loading Settings. A cleaner future version would seed that PAT through
+# the Settings constructor and re-enable library-managed auto-creation.
 def get_settings() -> Settings:
     """Actually return a settings object.
 

--- a/github_changelog_md/config/validation.py
+++ b/github_changelog_md/config/validation.py
@@ -1,0 +1,119 @@
+"""Validate and normalize changelog configuration."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import TYPE_CHECKING, Literal
+
+if TYPE_CHECKING:  # pragma: no cover
+    from github_changelog_md.config.settings import Settings
+    from github_changelog_md.constants import ChangelogOptions
+
+ItemOrder = Literal["newest-first", "oldest-first"]
+
+VALID_ITEM_ORDERS: tuple[ItemOrder, ...] = ("newest-first", "oldest-first")
+
+
+class ChangelogConfigError(ValueError):
+    """Raised when changelog configuration is invalid."""
+
+
+@dataclass(frozen=True, slots=True)
+class ReleaseConfigEntry:
+    """Normalized release-specific text configuration."""
+
+    release: str
+    value: str
+
+
+def validate_item_order(value: str) -> ItemOrder:
+    """Return a valid item order or raise a config error."""
+    if value in VALID_ITEM_ORDERS:
+        return value
+    valid_values = ", ".join(VALID_ITEM_ORDERS)
+    msg = f"item_order must be one of: {valid_values}"
+    raise ChangelogConfigError(msg)
+
+
+def validate_max_depends(value: int) -> int:
+    """Return a valid dependency display limit."""
+    if value >= 0:
+        return value
+    msg = "max_depends must be greater than or equal to 0"
+    raise ChangelogConfigError(msg)
+
+
+def validate_changelog_options(
+    options: ChangelogOptions,
+) -> ChangelogOptions:
+    """Validate resolved changelog options before running generation."""
+    options["item_order"] = validate_item_order(options["item_order"])
+    options["max_depends"] = validate_max_depends(options["max_depends"])
+    return options
+
+
+def validate_settings(settings: Settings) -> None:
+    """Validate settings values that need stricter domain checks."""
+    validate_item_order(settings.item_order)
+    validate_max_depends(settings.max_depends)
+    normalize_release_entries(settings.yanked, value_key="reason")
+    normalize_release_entries(settings.release_text_before, value_key="text")
+    normalize_release_entries(settings.release_text, value_key="text")
+    normalize_release_entries(settings.release_overrides, value_key="text")
+
+
+def normalize_release_entries(
+    values: list[dict[str, str]] | None,
+    value_key: str,
+    *,
+    strip_value: bool = False,
+) -> dict[str, str]:
+    """Build a release-tag keyed lookup table from config entries."""
+    if not values:
+        return {}
+
+    lookup: dict[str, str] = {}
+    for entry in _release_config_entries(
+        values,
+        value_key=value_key,
+        strip_value=strip_value,
+    ):
+        lookup[entry.release] = entry.value
+    return lookup
+
+
+def _release_config_entries(
+    values: list[dict[str, str]],
+    value_key: str,
+    *,
+    strip_value: bool,
+) -> list[ReleaseConfigEntry]:
+    """Return normalized release config entries."""
+    entries: list[ReleaseConfigEntry] = []
+    for index, value in enumerate(values, start=1):
+        release = _required_value(value, "release", index).strip()
+        text = _required_value(value, value_key, index)
+        if strip_value:
+            text = text.strip()
+        if not release:
+            msg = f"release entry {index} has an empty release tag"
+            raise ChangelogConfigError(msg)
+        entries.append(ReleaseConfigEntry(release=release, value=text))
+    return entries
+
+
+def _required_value(
+    value: dict[str, str],
+    key: str,
+    index: int,
+) -> str:
+    """Return a required release config value."""
+    try:
+        result = value[key]
+    except KeyError as exc:
+        msg = f"release entry {index} is missing '{key}'"
+        raise ChangelogConfigError(msg) from exc
+    if not isinstance(result, str):
+        msg = f"release entry {index} value '{key}' must be a string"
+        raise ChangelogConfigError(msg)
+    return result

--- a/github_changelog_md/helpers.py
+++ b/github_changelog_md/helpers.py
@@ -4,15 +4,19 @@ from __future__ import annotations
 
 import subprocess
 import sys
+from dataclasses import dataclass
 from importlib import metadata, resources
 from pathlib import Path
 from shutil import which
 from typing import Protocol
+from urllib.parse import urlparse
 
 import rtoml
 from rich import print as rprint
 
 from github_changelog_md.constants import SECTIONS, ExitErrors, SectionHeadings
+
+REMOTE_PATH_PARTS = 2
 
 
 class ReleaseTitle(Protocol):
@@ -25,6 +29,14 @@ class ReleaseTitle(Protocol):
     @property
     def tag_name(self) -> str | None:
         """Release tag name."""
+
+
+@dataclass(frozen=True, slots=True)
+class GitHubRemote:
+    """Repository reference parsed from a GitHub remote URL."""
+
+    owner: str
+    repo: str
 
 
 def get_toml_path() -> Path:
@@ -78,8 +90,8 @@ def header() -> None:
     )
 
 
-def get_repo_name() -> str | None:
-    """Return the name of the repository from the current directory."""
+def get_repo_remote() -> GitHubRemote | None:
+    """Return the GitHub owner/repo from the current directory."""
     git_executable = which("git")
     if git_executable is None:
         return None
@@ -94,12 +106,36 @@ def get_repo_name() -> str | None:
     except (subprocess.CalledProcessError, FileNotFoundError, OSError):
         return None
 
-    # Support HTTPS and SSH forms:
-    # https://github.com/user/repo.git, git@github.com:user/repo.git
-    repo_part = remote_url.rstrip("/").rsplit("/", maxsplit=1)[-1]
-    repo_name = repo_part.rsplit(":", maxsplit=1)[-1]
-    repo_name = repo_name.removesuffix(".git")
-    return repo_name.strip() or None
+    return parse_github_remote(remote_url)
+
+
+def get_repo_name() -> str | None:
+    """Return the name of the repository from the current directory."""
+    remote = get_repo_remote()
+    if remote is None:
+        return None
+    return remote.repo
+
+
+def parse_github_remote(remote_url: str) -> GitHubRemote | None:
+    """Parse a GitHub remote URL into owner and repository name."""
+    if remote_url.startswith("git@github.com:"):
+        path = remote_url.removeprefix("git@github.com:")
+    else:
+        parsed = urlparse(remote_url)
+        if parsed.hostname != "github.com":
+            return None
+        path = parsed.path
+
+    parts = [part for part in path.strip("/").split("/") if part]
+    if len(parts) != REMOTE_PATH_PARTS:
+        return None
+
+    owner, repo = parts
+    repo = repo.removesuffix(".git")
+    if not owner or not repo:
+        return None
+    return GitHubRemote(owner=owner, repo=repo)
 
 
 def cap_first_letter(string: str) -> str:

--- a/github_changelog_md/helpers.py
+++ b/github_changelog_md/helpers.py
@@ -7,15 +7,24 @@ import sys
 from importlib import metadata, resources
 from pathlib import Path
 from shutil import which
-from typing import TYPE_CHECKING
+from typing import Protocol
 
 import rtoml
 from rich import print as rprint
 
 from github_changelog_md.constants import SECTIONS, ExitErrors, SectionHeadings
 
-if TYPE_CHECKING:  # pragma: no cover
-    from github.GitRelease import GitRelease
+
+class ReleaseTitle(Protocol):
+    """Release title/tag fields used to decide whether to show a title."""
+
+    @property
+    def title(self) -> str | None:
+        """Release display title."""
+
+    @property
+    def tag_name(self) -> str | None:
+        """Release tag name."""
 
 
 def get_toml_path() -> Path:
@@ -129,7 +138,7 @@ def strip_first_alpha_char(version_string: str) -> str:
     return version_string
 
 
-def title_unique(release: GitRelease) -> bool:
+def title_unique(release: ReleaseTitle) -> bool:
     """Ensures that the release title and tag name are not the same.
 
     It will remove the first alpha character from the title and tag (if it is a

--- a/github_changelog_md/main.py
+++ b/github_changelog_md/main.py
@@ -1,10 +1,9 @@
 """Entry point for the main application loop."""
 
-# ruff: noqa: FBT001
 from __future__ import annotations
 
 import sys
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Annotated
 
 import typer
 from rich import print as rprint
@@ -33,130 +32,166 @@ app = typer.Typer(
 
 @app.command()
 def main(
-    version: bool | None = typer.Option(
-        None,
-        "-v",
-        "--version",
-        is_eager=True,
-    ),
-    repo: str | None = typer.Option(
-        None,
-        "--repo",
-        "-r",
-        help="Name of the repository to generate the Changelog for.",
-        show_default=False,
-    ),
-    user: str | None = typer.Option(
-        None,
-        "--user",
-        "-u",
-        help="Name of the user or organisation that owns the repository.",
-        show_default=False,
-    ),
-    next_release: str | None = typer.Option(
-        None,
-        "--next-release",
-        "-n",
-        help="Name of the next release to generate the changelog for.",
-        show_default=False,
-    ),
-    unreleased: bool | None = typer.Option(
-        default=None,
-        help=(
-            "Show unreleased changes in the Changelog, defaults to [bold]True"
-            "[/bold]."
+    version: Annotated[
+        bool | None,
+        typer.Option(
+            "-v",
+            "--version",
+            is_eager=True,
         ),
-        show_default=False,
-    ),
-    contrib: bool | None = typer.Option(
-        default=None,
-        help="Update the CONTRIBUTORS.md file, defaults to [bold]False[/bold].",
-        show_default=False,
-    ),
-    depends: bool | None = typer.Option(
-        default=None,
-        help=(
-            "Show dependency updates in the Changelog, defaults to [bold]True"
-            "[/bold]."
+    ] = None,
+    repo: Annotated[
+        str | None,
+        typer.Option(
+            "--repo",
+            "-r",
+            help="Name of the repository to generate the Changelog for.",
+            show_default=False,
         ),
-        show_default=False,
-    ),
-    output: str | None = typer.Option(
-        None,
-        "--output",
-        "-o",
-        help="Output file to write the Changelog to.",
-        show_default=False,
-    ),
-    quiet: bool | None = typer.Option(
-        None,
-        "--quiet",
-        "-q",
-        help="Suppress all output except errors.",
-        show_default=False,
-    ),
-    skip: list[str] | None = typer.Option(  # noqa: B008
-        [],
-        "--skip",
-        "-s",
-        help="Skip the suplied tag. Can be specified multiple times",
-        show_default=False,
-    ),
-    issues: bool | None = typer.Option(
-        default=None,
-        help=(
-            "Show CLOSED issues in the Changelog, defaults to [bold]True"
-            "[/bold]."
+    ] = None,
+    user: Annotated[
+        str | None,
+        typer.Option(
+            "--user",
+            "-u",
+            help="Name of the user or organisation that owns the repository.",
+            show_default=False,
         ),
-        show_default=False,
-    ),
-    item_order: str | None = typer.Option(
-        None,
-        "--item-order",
-        "-i",
-        help=(
-            "Order of PRs and Issues in a release section. "
-            "Valid options are [bold]'newest-first'[/bold] or [bold]'oldest-"
-            "first'[/bold]. Defaults to [bold]'newest-first'[/bold]."
+    ] = None,
+    next_release: Annotated[
+        str | None,
+        typer.Option(
+            "--next-release",
+            "-n",
+            help="Name of the next release to generate the changelog for.",
+            show_default=False,
         ),
-        show_default=False,
-    ),
-    ignore: list[int] | None = typer.Option(  # noqa: B008
-        [],
-        "--ignore",
-        "-e",
-        help=(
-            "Ignore the supplied PR or Issue by its number. Can be specified "
-            "multiple times."
+    ] = None,
+    unreleased: Annotated[
+        bool | None,
+        typer.Option(
+            help=(
+                "Show unreleased changes in the Changelog, defaults to "
+                "[bold]True[/bold]."
+            ),
+            show_default=False,
         ),
-        show_default=False,
-    ),
-    max_depends: int | None = typer.Option(
-        None,
-        "--max-depends",
-        "-m",
-        help=(
-            "Maximum number of dependency updates to show in the Changelog. "
-            "Defaults to [bold]10[/bold]."
+    ] = None,
+    contrib: Annotated[
+        bool | None,
+        typer.Option(
+            help=(
+                "Update the CONTRIBUTORS.md file, defaults to "
+                "[bold]False[/bold]."
+            ),
+            show_default=False,
         ),
-        show_default=False,
-    ),
-    show_diff: bool | None = typer.Option(
-        default=None,
-        help=(
-            "Show the diff of the PRs and Issues in the Changelog, defaults "
-            "to [bold]True[/bold]."
+    ] = None,
+    depends: Annotated[
+        bool | None,
+        typer.Option(
+            help=(
+                "Show dependency updates in the Changelog, defaults to "
+                "[bold]True[/bold]."
+            ),
+            show_default=False,
         ),
-        show_default=False,
-    ),
-    show_patch: bool | None = typer.Option(
-        default=None,
-        help=(
-            "Show the patch of the PRs and Issues in the Changelog, defaults "
-            "to [bold]True[/bold]."
+    ] = None,
+    output: Annotated[
+        str | None,
+        typer.Option(
+            "--output",
+            "-o",
+            help="Output file to write the Changelog to.",
+            show_default=False,
         ),
-        show_default=False,
-    ),
+    ] = None,
+    quiet: Annotated[
+        bool | None,
+        typer.Option(
+            "--quiet",
+            "-q",
+            help="Suppress all output except errors.",
+            show_default=False,
+        ),
+    ] = None,
+    skip: Annotated[
+        list[str] | None,
+        typer.Option(
+            "--skip",
+            "-s",
+            help="Skip the supplied tag. Can be specified multiple times",
+            show_default=False,
+        ),
+    ] = None,
+    issues: Annotated[
+        bool | None,
+        typer.Option(
+            help=(
+                "Show CLOSED issues in the Changelog, defaults to "
+                "[bold]True[/bold]."
+            ),
+            show_default=False,
+        ),
+    ] = None,
+    item_order: Annotated[
+        str | None,
+        typer.Option(
+            "--item-order",
+            "-i",
+            help=(
+                "Order of PRs and Issues in a release section. Valid options "
+                "are [bold]'newest-first'[/bold] or "
+                "[bold]'oldest-first'[/bold]."
+                " Defaults to [bold]'newest-first'[/bold]."
+            ),
+            show_default=False,
+        ),
+    ] = None,
+    ignore: Annotated[
+        list[int] | None,
+        typer.Option(
+            "--ignore",
+            "-e",
+            help=(
+                "Ignore the supplied PR or Issue by its number. Can be "
+                "specified multiple times."
+            ),
+            show_default=False,
+        ),
+    ] = None,
+    max_depends: Annotated[
+        int | None,
+        typer.Option(
+            "--max-depends",
+            "-m",
+            help=(
+                "Maximum number of dependency updates to show in the "
+                "Changelog. Defaults to [bold]10[/bold]."
+            ),
+            show_default=False,
+        ),
+    ] = None,
+    show_diff: Annotated[
+        bool | None,
+        typer.Option(
+            help=(
+                "Show the diff of the PRs and Issues in the Changelog, "
+                "defaults to [bold]True[/bold]."
+            ),
+            show_default=False,
+        ),
+    ] = None,
+    show_patch: Annotated[
+        bool | None,
+        typer.Option(
+            help=(
+                "Show the patch of the PRs and Issues in the Changelog, "
+                "defaults to [bold]True[/bold]."
+            ),
+            show_default=False,
+        ),
+    ] = None,
 ) -> None:
     """Generate your CHANGELOG file Automatically from GitHub."""
     if version:
@@ -176,7 +211,6 @@ def main(
             user = user or repo_remote.owner
 
         if not repo:
-            # cant find a local repo and none specified on the cmd line.
             rprint(
                 "[red]  ->  Could not find a local repository, "
                 "Please use the --repo option.\n",
@@ -205,7 +239,9 @@ def main(
                     settings.contrib if contrib is None else contrib
                 ),
                 "quiet": settings.quiet if quiet is None else quiet,
-                "skip_releases": settings.skip_releases if skip == [] else skip,
+                "skip_releases": settings.skip_releases
+                if skip is None
+                else skip,
                 "show_issues": (
                     settings.show_issues if issues is None else issues
                 ),
@@ -213,7 +249,7 @@ def main(
                     settings.item_order if item_order is None else item_order
                 ),
                 "ignore_items": (
-                    settings.ignore_items if ignore == [] else ignore
+                    settings.ignore_items if ignore is None else ignore
                 ),
                 "max_depends": (
                     settings.max_depends if max_depends is None else max_depends

--- a/github_changelog_md/main.py
+++ b/github_changelog_md/main.py
@@ -12,6 +12,11 @@ from rich import print as rprint
 from github_changelog_md.changelog import ChangeLog
 from github_changelog_md.changelog.github_data import GitHubDataSource
 from github_changelog_md.config import get_settings
+from github_changelog_md.config.validation import (
+    ChangelogConfigError,
+    validate_changelog_options,
+    validate_settings,
+)
 from github_changelog_md.constants import ExitErrors
 from github_changelog_md.helpers import get_app_version, get_repo_name
 
@@ -178,26 +183,49 @@ def main(
 
     settings = get_settings()
 
-    options: ChangelogOptions = {
-        "user_name": user,
-        "next_release": next_release,
-        "show_unreleased": (
-            settings.unreleased if unreleased is None else unreleased
-        ),
-        "show_depends": settings.depends if depends is None else depends,
-        "output_file": settings.output_file if output is None else output,
-        "contributors": settings.contrib if contrib is None else contrib,
-        "quiet": settings.quiet if quiet is None else quiet,
-        "skip_releases": settings.skip_releases if skip == [] else skip,
-        "show_issues": settings.show_issues if issues is None else issues,
-        "item_order": settings.item_order if item_order is None else item_order,
-        "ignore_items": settings.ignore_items if ignore == [] else ignore,
-        "max_depends": settings.max_depends
-        if max_depends is None
-        else max_depends,
-        "show_diff": settings.show_diff if show_diff is None else show_diff,
-        "show_patch": settings.show_patch if show_patch is None else show_patch,
-    }
+    try:
+        validate_settings(settings)
+        options: ChangelogOptions = validate_changelog_options(
+            {
+                "user_name": user,
+                "next_release": next_release,
+                "show_unreleased": (
+                    settings.unreleased if unreleased is None else unreleased
+                ),
+                "show_depends": (
+                    settings.depends if depends is None else depends
+                ),
+                "output_file": (
+                    settings.output_file if output is None else output
+                ),
+                "contributors": (
+                    settings.contrib if contrib is None else contrib
+                ),
+                "quiet": settings.quiet if quiet is None else quiet,
+                "skip_releases": settings.skip_releases if skip == [] else skip,
+                "show_issues": (
+                    settings.show_issues if issues is None else issues
+                ),
+                "item_order": (
+                    settings.item_order if item_order is None else item_order
+                ),
+                "ignore_items": (
+                    settings.ignore_items if ignore == [] else ignore
+                ),
+                "max_depends": (
+                    settings.max_depends if max_depends is None else max_depends
+                ),
+                "show_diff": (
+                    settings.show_diff if show_diff is None else show_diff
+                ),
+                "show_patch": (
+                    settings.show_patch if show_patch is None else show_patch
+                ),
+            }
+        )
+    except ChangelogConfigError as exc:
+        rprint(f"\n[red]  X  Error: {exc}[/red]\n", file=sys.stderr)
+        raise typer.Exit(ExitErrors.INVALID_ACTION) from exc
 
     try:
         data_source = GitHubDataSource(settings.github_pat)

--- a/github_changelog_md/main.py
+++ b/github_changelog_md/main.py
@@ -10,7 +10,9 @@ import typer
 from rich import print as rprint
 
 from github_changelog_md.changelog import ChangeLog
+from github_changelog_md.changelog.github_data import GitHubDataSource
 from github_changelog_md.config import get_settings
+from github_changelog_md.constants import ExitErrors
 from github_changelog_md.helpers import get_app_version, get_repo_name
 
 if TYPE_CHECKING:
@@ -197,5 +199,14 @@ def main(
         "show_patch": settings.show_patch if show_patch is None else show_patch,
     }
 
-    changelog = ChangeLog(repo, options)
+    try:
+        data_source = GitHubDataSource(settings.github_pat)
+    except AttributeError as exc:
+        rprint(
+            "\n[red]  X  Error: No GitHub PAT found in settings file\n",
+            file=sys.stderr,
+        )
+        raise typer.Exit(ExitErrors.NO_PAT) from exc
+
+    changelog = ChangeLog(repo, options, settings, data_source)
     changelog.run()

--- a/github_changelog_md/main.py
+++ b/github_changelog_md/main.py
@@ -18,7 +18,7 @@ from github_changelog_md.config.validation import (
     validate_settings,
 )
 from github_changelog_md.constants import ExitErrors
-from github_changelog_md.helpers import get_app_version, get_repo_name
+from github_changelog_md.helpers import get_app_version, get_repo_remote
 
 if TYPE_CHECKING:
     from github_changelog_md.constants import ChangelogOptions
@@ -170,7 +170,10 @@ def main(
 
     if not repo:
         # Try to get the repo from the current directory.
-        repo = get_repo_name()
+        repo_remote = get_repo_remote()
+        if repo_remote:
+            repo = repo_remote.repo
+            user = user or repo_remote.owner
 
         if not repo:
             # cant find a local repo and none specified on the cmd line.

--- a/github_changelog_md/main.py
+++ b/github_changelog_md/main.py
@@ -9,7 +9,7 @@ from typing import TYPE_CHECKING
 import typer
 from rich import print as rprint
 
-from github_changelog_md.changelog import ChangeLog
+from github_changelog_md.changelog import ChangeLog, build_release_text_cache
 from github_changelog_md.changelog.github_data import GitHubDataSource
 from github_changelog_md.config import get_settings
 from github_changelog_md.config.validation import (
@@ -231,7 +231,7 @@ def main(
         raise typer.Exit(ExitErrors.INVALID_ACTION) from exc
 
     try:
-        data_source = GitHubDataSource(settings.github_pat)
+        data_source = GitHubDataSource.from_token(settings.github_pat)
     except AttributeError as exc:
         rprint(
             "\n[red]  X  Error: No GitHub PAT found in settings file\n",
@@ -239,5 +239,11 @@ def main(
         )
         raise typer.Exit(ExitErrors.NO_PAT) from exc
 
-    changelog = ChangeLog(repo, options, settings, data_source)
+    changelog = ChangeLog(
+        repo,
+        options,
+        settings,
+        data_source,
+        build_release_text_cache(settings),
+    )
     changelog.run()

--- a/tests/test_changelog.py
+++ b/tests/test_changelog.py
@@ -17,7 +17,10 @@ from github_changelog_md.changelog.bucketing import (
     bucket_pull_requests,
     get_unreleased_cutoff,
 )
-from github_changelog_md.changelog.changelog import ChangeLog
+from github_changelog_md.changelog.changelog import (
+    ChangeLog,
+    build_release_text_cache,
+)
 from github_changelog_md.changelog.github_data import (
     GitHubDataSource,
     ItemCountColumn,
@@ -88,7 +91,13 @@ def _build_changelog(
         for key, value in settings_overrides.items():
             setattr(settings, key, value)
 
-    return ChangeLog("repo", _default_options(), settings, data_source)
+    return ChangeLog(
+        "repo",
+        _default_options(),
+        settings,
+        data_source,
+        build_release_text_cache(settings),
+    )
 
 
 @pytest.fixture
@@ -514,6 +523,25 @@ class TestChangelogModels:
 class TestGitHubDataSource:
     """Tests for the GitHub data source boundary."""
 
+    def test_from_token_builds_github_client(self, mocker) -> None:
+        """Test token factory owns GitHub client construction."""
+        auth = MagicMock()
+        git = MagicMock()
+        auth_token = mocker.patch(
+            "github_changelog_md.changelog.github_data.Auth.Token",
+            return_value=auth,
+        )
+        github = mocker.patch(
+            "github_changelog_md.changelog.github_data.Github",
+            return_value=git,
+        )
+
+        data_source = GitHubDataSource.from_token("token")
+
+        auth_token.assert_called_once_with("token")
+        github.assert_called_once_with(auth=auth)
+        assert data_source.git is git
+
     def test_item_count_column_handles_unknown_total(self) -> None:
         """Test progress counts omit invalid totals."""
         expected_count = 7
@@ -524,7 +552,6 @@ class TestGitHubDataSource:
     def test_fetch_methods_report_progress(self, mocker) -> None:
         """Test GitHub item adaptation advances visible progress."""
         expected_total = 3
-        mocker.patch("github_changelog_md.changelog.github_data.Github")
         progress = MagicMock()
         progress.__enter__.return_value = progress
         progress.add_task.return_value = "task-id"
@@ -532,7 +559,7 @@ class TestGitHubDataSource:
             "github_changelog_md.changelog.github_data.Progress",
             return_value=progress,
         )
-        data_source = GitHubDataSource("token")
+        data_source = GitHubDataSource(MagicMock())
         user = MagicMock()
         user.login = "dev"
         user.html_url = "https://github.com/dev"
@@ -566,7 +593,6 @@ class TestGitHubDataSource:
 
     def test_fetch_progress_handles_unknown_total(self, mocker) -> None:
         """Test progress uses an unknown total when GitHub count is invalid."""
-        mocker.patch("github_changelog_md.changelog.github_data.Github")
         progress = MagicMock()
         progress.__enter__.return_value = progress
         progress.add_task.return_value = "task-id"
@@ -574,7 +600,7 @@ class TestGitHubDataSource:
             "github_changelog_md.changelog.github_data.Progress",
             return_value=progress,
         )
-        data_source = GitHubDataSource("token")
+        data_source = GitHubDataSource(MagicMock())
         user = MagicMock()
         user.login = "reporter"
         user.html_url = "https://github.com/reporter"
@@ -600,7 +626,7 @@ class TestGitHubDataSource:
             "Loading issue candidates", total=None
         )
 
-    def test_get_repo_data_returns_repository_model(self, mocker) -> None:
+    def test_get_repo_data_returns_repository_model(self) -> None:
         """Test repository lookup converts PyGithub data."""
         git = MagicMock()
         current_user = MagicMock(login="owner")
@@ -611,12 +637,8 @@ class TestGitHubDataSource:
         repo.html_url = "https://github.com/owner/repo"
         owner_user.get_repo.return_value = repo
         git.get_user.side_effect = [current_user, owner_user]
-        mocker.patch(
-            "github_changelog_md.changelog.github_data.Github",
-            return_value=git,
-        )
 
-        data_source = GitHubDataSource("token")
+        data_source = GitHubDataSource(git)
 
         assert data_source.get_repo_data("repo", None) == ChangelogRepository(
             name="repo",
@@ -625,10 +647,9 @@ class TestGitHubDataSource:
         )
         owner_user.get_repo.assert_called_once_with("repo")
 
-    def test_fetch_methods_return_domain_models(self, mocker) -> None:
+    def test_fetch_methods_return_domain_models(self) -> None:
         """Test release, PR, issue, and first commit fetch paths."""
-        mocker.patch("github_changelog_md.changelog.github_data.Github")
-        data_source = GitHubDataSource("token")
+        data_source = GitHubDataSource(MagicMock())
 
         label = MagicMock()
         label.name = "bug"
@@ -711,8 +732,7 @@ class TestGitHubDataSource:
 
     def test_fetch_methods_route_github_errors(self, mocker) -> None:
         """Test GitHub exceptions use the shared exit path."""
-        mocker.patch("github_changelog_md.changelog.github_data.Github")
-        data_source = GitHubDataSource("token")
+        data_source = GitHubDataSource(MagicMock())
         data_source.repo_data = MagicMock()
         data_source.repo_data.get_issues.side_effect = GithubException(
             status=500,
@@ -736,15 +756,11 @@ class TestGitHubDataSource:
             status=404,
             data={"message": "missing"},
         )
-        mocker.patch(
-            "github_changelog_md.changelog.github_data.Github",
-            return_value=git,
-        )
         git_error_mock = mocker.patch(
             "github_changelog_md.changelog.github_data.git_error",
             side_effect=typer.Exit(ExitErrors.GIT_ERROR),
         )
-        data_source = GitHubDataSource("token")
+        data_source = GitHubDataSource(git)
 
         with pytest.raises(typer.Exit):
             data_source.get_repo_data("repo", None)
@@ -767,10 +783,9 @@ class TestGitHubDataSource:
 
         assert git_error_mock.call_count == len(expected_errors)
 
-    def test_fetch_requires_repository_data(self, mocker) -> None:
+    def test_fetch_requires_repository_data(self) -> None:
         """Test fetch methods require repository lookup first."""
-        mocker.patch("github_changelog_md.changelog.github_data.Github")
-        data_source = GitHubDataSource("token")
+        data_source = GitHubDataSource(MagicMock())
 
         with pytest.raises(RuntimeError, match="Repository data"):
             data_source.get_first_commit_date()
@@ -928,42 +943,43 @@ class TestChangelog:
         changelog.link_issues.assert_called_once()
         changelog.generate_changelog.assert_called_once()
 
-    def test_build_release_cache_maps_are_created(self, mocker) -> None:
-        """Test release lookup caches are built at initialization."""
-        changelog = _build_changelog(
-            mocker,
-            {
-                "yanked": [{"release": " v1.0.0 ", "reason": "bad build"}],
-                "release_text_before": [
-                    {"release": " v1.0.0 ", "text": " before text "}
-                ],
-                "release_text": [
-                    {"release": " v1.0.0 ", "text": " release text "}
-                ],
-                "release_overrides": [
-                    {"release": " v1.0.0 ", "text": "override text"}
-                ],
-            },
+    def test_constructor_does_not_read_release_settings(self) -> None:
+        """Test release text config is supplied instead of read on init."""
+        settings = MagicMock(spec=[])
+        data_source = MagicMock(spec=GitHubDataSource)
+
+        changelog = ChangeLog(
+            "repo",
+            _default_options(),
+            settings,
+            data_source,
         )
 
-        assert (
-            changelog.release_text_cache.yanked_by_release["v1.0.0"]
-            == "bad build"
-        )
-        assert (
-            changelog.release_text_cache.release_text_before_by_release[
-                "v1.0.0"
-            ]
-            == "before text"
-        )
-        assert (
-            changelog.release_text_cache.release_text_by_release["v1.0.0"]
-            == "release text"
-        )
-        assert (
-            changelog.release_text_cache.release_overrides_by_release["v1.0.0"]
-            == "override text"
-        )
+        assert changelog.release_text_cache.yanked_by_release == {}
+        assert changelog.release_text_cache.release_text_before_by_release == {}
+        assert changelog.release_text_cache.release_text_by_release == {}
+        assert changelog.release_text_cache.release_overrides_by_release == {}
+
+    def test_build_release_cache_maps_are_created(self) -> None:
+        """Test release lookup caches are built from settings."""
+        settings = MagicMock()
+        settings.yanked = [{"release": " v1.0.0 ", "reason": "bad build"}]
+        settings.release_text_before = [
+            {"release": " v1.0.0 ", "text": " before text "}
+        ]
+        settings.release_text = [
+            {"release": " v1.0.0 ", "text": " release text "}
+        ]
+        settings.release_overrides = [
+            {"release": " v1.0.0 ", "text": "override text"}
+        ]
+
+        cache = build_release_text_cache(settings)
+
+        assert cache.yanked_by_release["v1.0.0"] == "bad build"
+        assert cache.release_text_before_by_release["v1.0.0"] == "before text"
+        assert cache.release_text_by_release["v1.0.0"] == "release text"
+        assert cache.release_overrides_by_release["v1.0.0"] == "override text"
 
     def test_build_release_lookup_rejects_missing_value_key(self) -> None:
         """Test release lookup config requires the expected value key."""
@@ -984,6 +1000,17 @@ class TestChangelog:
         ):
             ChangeLog.build_release_lookup(
                 [{"release": "  ", "text": "Release note"}],
+                value_key="text",
+            )
+
+    def test_build_release_lookup_rejects_non_string_value(self) -> None:
+        """Test release lookup config values must be strings."""
+        with pytest.raises(
+            ChangelogConfigError,
+            match="release entry 1 value 'text' must be a string",
+        ):
+            ChangeLog.build_release_lookup(
+                cast("Any", [{"release": "v1.0.0", "text": 123}]),
                 value_key="text",
             )
 
@@ -1995,6 +2022,14 @@ class TestChangelog:
             match="item_order must be one of",
         ):
             validate_changelog_options(options)
+
+    def test_get_sorted_items_rejects_unknown_order(self, mocker) -> None:
+        """Test renderer fails clearly if invalid ordering reaches it."""
+        changelog = _build_changelog(mocker)
+        changelog.options["item_order"] = "keep"
+
+        with pytest.raises(ValueError, match="Unknown item order: keep"):
+            changelog.get_sorted_items([MagicMock(number=1)])
 
     def test_get_unreleased_cutoff_uses_first_commit_when_no_releases(
         self,

--- a/tests/test_changelog.py
+++ b/tests/test_changelog.py
@@ -2,7 +2,7 @@
 
 import datetime
 from collections.abc import Mapping
-from dataclasses import dataclass, field
+from dataclasses import dataclass, field, replace
 from pathlib import Path
 from typing import Any, cast
 from unittest.mock import MagicMock
@@ -12,6 +12,11 @@ import typer
 from github import GithubException
 from github.GitRelease import GitRelease
 
+from github_changelog_md.changelog.bucketing import (
+    bucket_issues,
+    bucket_pull_requests,
+    get_unreleased_cutoff,
+)
 from github_changelog_md.changelog.changelog import ChangeLog
 from github_changelog_md.changelog.github_data import (
     GitHubDataSource,
@@ -765,6 +770,96 @@ class TestGitHubDataSource:
 
         with pytest.raises(RuntimeError, match="Repository data"):
             data_source.get_first_commit_date()
+
+
+class TestChangelogBucketing:
+    """Tests for pure release bucketing logic."""
+
+    def test_unreleased_cutoff_uses_latest_release_date(self) -> None:
+        """Test cutoff is independent of release list order."""
+        fallback_date = _date(2020, 1, 1)
+        releases = [
+            _release(1, "v1.0.0", "Old", _date(2021, 1, 1)),
+            _release(2, "v2.0.0", "New", _date(2021, 1, 10)),
+        ]
+
+        assert get_unreleased_cutoff(releases[::-1], fallback_date) == _date(
+            2021, 1, 10
+        )
+
+    def test_unreleased_cutoff_uses_fallback_without_releases(self) -> None:
+        """Test cutoff uses first commit date when there are no releases."""
+        fallback_date = _date(2020, 1, 1)
+
+        assert get_unreleased_cutoff([], fallback_date) == fallback_date
+
+    def test_bucket_pull_requests_sorts_releases_and_tracks_unreleased(
+        self,
+    ) -> None:
+        """Test PRs are assigned by date regardless of release input order."""
+        releases = [
+            _release(2, "v2.0.0", "New", _date(2021, 1, 10)),
+            _release(1, "v1.0.0", "Old", _date(2021, 1, 1)),
+        ]
+        pr_old = replace(_pr(1, "old", "dev", []), merged_at=_date(2021, 1, 1))
+        pr_new = replace(_pr(2, "new", "dev", []), merged_at=_date(2021, 1, 5))
+        pr_unreleased = replace(
+            _pr(3, "unreleased", "dev", []),
+            merged_at=_date(2021, 1, 11),
+        )
+        pr_undated = _pr(4, "undated", "dev", [])
+
+        result = bucket_pull_requests(
+            releases,
+            [pr_unreleased, pr_undated, pr_new, pr_old],
+            _date(2021, 1, 10),
+            [],
+        )
+
+        assert result.by_release[1] == [pr_old]
+        assert result.by_release[2] == [pr_new]
+        assert result.unreleased == [pr_unreleased]
+
+    def test_bucket_pull_requests_handles_exact_release_timestamp(self) -> None:
+        """Test an item exactly on a release timestamp belongs to it."""
+        release = _release(1, "v1.0.0", "Release", _date(2021, 1, 1))
+        pull_request = replace(
+            _pr(1, "exact", "dev", []),
+            merged_at=release.created_at,
+        )
+
+        result = bucket_pull_requests(
+            [release],
+            [pull_request],
+            release.created_at,
+            [],
+        )
+
+        assert result.by_release[1] == [pull_request]
+        assert result.unreleased == []
+
+    def test_bucket_issues_ignores_users_and_no_release_unreleased(
+        self,
+    ) -> None:
+        """Test issue bucketing ignores configured users and no-release path."""
+        issue = replace(
+            _issue(1, "issue", "dev", []),
+            closed_at=_date(2021, 1, 2),
+        )
+        ignored = replace(
+            _issue(2, "ignored", "bot", []),
+            closed_at=_date(2021, 1, 3),
+        )
+
+        result = bucket_issues(
+            [],
+            [ignored, issue],
+            _date(2021, 1, 1),
+            ["bot"],
+        )
+
+        assert result.by_release == {}
+        assert result.unreleased == [issue]
 
 
 class TestChangelog:
@@ -1594,7 +1689,7 @@ class TestChangelog:
             ),
         )
         changelog.repo_releases = [rel_new, rel_old]
-        changelog.get_latest_release_date = MagicMock(
+        changelog.get_unreleased_cutoff = MagicMock(
             return_value=datetime.datetime(
                 2021, 1, 10, tzinfo=datetime.timezone.utc
             )
@@ -1895,17 +1990,27 @@ class TestChangelog:
         items = [MagicMock(number=2), MagicMock(number=1)]
         assert changelog.get_sorted_items(items) is items
 
-    def test_get_latest_release_date_uses_first_commit_when_no_releases(
+    def test_get_unreleased_cutoff_uses_first_commit_when_no_releases(
         self,
         mocker,
     ) -> None:
-        """Test get_latest_release_date falls back to first commit date."""
+        """Test get_unreleased_cutoff falls back to first commit date."""
         changelog = _build_changelog(mocker)
         changelog.repo_releases = []
         first_date = datetime.datetime(2020, 1, 1, tzinfo=datetime.timezone.utc)
         changelog.data_source.get_first_commit_date.return_value = first_date
 
-        assert changelog.get_latest_release_date() == first_date
+        assert changelog.get_unreleased_cutoff() == first_date
+
+    def test_get_unreleased_cutoff_uses_latest_release(self, mocker) -> None:
+        """Test get_unreleased_cutoff is independent of release list order."""
+        changelog = _build_changelog(mocker)
+        changelog.repo_releases = [
+            _release(1, "v1.0.0", "Old", _date(2021, 1, 1)),
+            _release(2, "v2.0.0", "New", _date(2021, 1, 10)),
+        ]
+
+        assert changelog.get_unreleased_cutoff() == _date(2021, 1, 10)
 
     def test_filter_issues_drops_pull_requests(self, mocker) -> None:
         """Test filter_issues keeps only issues without pull_request marker."""

--- a/tests/test_changelog.py
+++ b/tests/test_changelog.py
@@ -1069,11 +1069,8 @@ class TestChangelog:
         """Test process_unreleased writes heading and links to HEAD."""
         changelog = _build_changelog(mocker)
         changelog.repo_data = MagicMock(html_url="https://github.com/user/repo")
-        changelog.unreleased = [MagicMock()]
+        changelog.unreleased = [_pr(1, "pending change", "dev", [])]
         changelog.unreleased_issues = []
-        changelog.show_release_text = MagicMock()
-        changelog.rprint_issues = MagicMock()
-        changelog.rprint_prs = MagicMock()
 
         out = MagicMock()
         changelog.process_unreleased(out)
@@ -1082,10 +1079,7 @@ class TestChangelog:
         assert "## [Unreleased]" in rendered
         assert "/tree/HEAD" in rendered
         assert changelog.prev_release == "HEAD"
-        changelog.show_release_text.assert_called_once_with(
-            out,
-            "unreleased",
-        )
+        assert "Pending change" in rendered
 
     def test_process_unreleased_with_next_release_uses_tag_link(
         self,
@@ -1095,11 +1089,8 @@ class TestChangelog:
         changelog = _build_changelog(mocker)
         changelog.options["next_release"] = "v2.0.0"
         changelog.repo_data = MagicMock(html_url="https://github.com/user/repo")
-        changelog.unreleased = []
-        changelog.unreleased_issues = [MagicMock()]
-        changelog.show_release_text = MagicMock()
-        changelog.rprint_issues = MagicMock()
-        changelog.rprint_prs = MagicMock()
+        changelog.unreleased = [_pr(1, "pending change", "dev", [])]
+        changelog.unreleased_issues = []
 
         out = MagicMock()
         changelog.process_unreleased(out)
@@ -1107,10 +1098,7 @@ class TestChangelog:
         rendered = "".join(call.args[0] for call in out.write.call_args_list)
         assert "## [v2.0.0]" in rendered
         assert "/releases/tag/v2.0.0" in rendered
-        changelog.show_release_text.assert_called_once_with(
-            out,
-            "v2.0.0",
-        )
+        assert "Pending change" in rendered
 
     def test_generate_diff_url_with_diff_and_patch(self, mocker) -> None:
         """Test generate_diff_url renders changelog, diff, and patch links."""
@@ -1186,12 +1174,11 @@ class TestChangelog:
         assert "and 1 more dependency updates" in rendered
 
     def test_process_release_falls_back_to_release_body(self, mocker) -> None:
-        """Test process_release calls get_release_body when lists are empty."""
+        """Test process_release renders release body when lists are empty."""
         changelog = _build_changelog(mocker)
         changelog.prev_release = None
         changelog.pr_by_release = {}
         changelog.issue_by_release = {}
-        changelog.get_release_body = MagicMock()
 
         release = MagicMock()
         release.id = 1
@@ -1204,11 +1191,13 @@ class TestChangelog:
             1,
             tzinfo=datetime.timezone.utc,
         )
+        release.body = None
 
         out = MagicMock()
         changelog.process_release(out, release)
+        rendered = "".join(call.args[0] for call in out.write.call_args_list)
 
-        changelog.get_release_body.assert_called_once_with(out, release)
+        assert "There were no merged pull requests" in rendered
 
     def test_get_release_body_strips_compare_link_and_adds_newline(
         self,
@@ -1843,8 +1832,6 @@ class TestChangelog:
         changelog.options["skip_releases"] = ["v0.9.0"]
         changelog.options["show_depends"] = False
         changelog.options["show_unreleased"] = True
-        changelog.process_unreleased = MagicMock()
-        changelog.process_release = MagicMock()
 
         mock_path = mocker.patch("github_changelog_md.changelog.changelog.Path")
         mock_path.cwd.return_value = Path("test_cwd")
@@ -1858,9 +1845,7 @@ class TestChangelog:
             call.args[0] for call in file_handle.write.call_args_list
         )
         assert "Dependency updates are excluded" in rendered
-        changelog.process_unreleased.assert_called_once()
-        changelog.process_release.assert_called_once()
-        assert changelog.prev_release == changelog.repo_releases[0]
+        assert "This changelog was generated using" in rendered
 
     def test_process_release_skip_prev_release_and_title(
         self,
@@ -1884,23 +1869,14 @@ class TestChangelog:
 
         changelog.options["skip_releases"] = None
         changelog.prev_release = "HEAD"
-        changelog.generate_diff_url = MagicMock()
-        changelog.show_before_text = MagicMock()
-        changelog.check_yanked = MagicMock()
-        changelog.show_release_text = MagicMock()
-        changelog.rprint_issues = MagicMock()
-        changelog.rprint_prs = MagicMock()
-        changelog.pr_by_release = {1: [MagicMock()]}
-        changelog.issue_by_release = {1: [MagicMock()]}
-        mocker.patch(
-            "github_changelog_md.changelog.changelog.title_unique",
-            return_value=True,
-        )
+        changelog.pr_by_release = {}
+        changelog.issue_by_release = {}
+        release.body = None
         out = MagicMock()
         changelog.process_release(out, release)
         rendered = "".join(call.args[0] for call in out.write.call_args_list)
         assert "**_Release Title_**" in rendered
-        changelog.generate_diff_url.assert_called_once()
+        assert "[`Full Changelog`]" in rendered
 
     def test_show_release_text_accepts_release_instance(self, mocker) -> None:
         """Test show_release_text branch when given a release instance."""

--- a/tests/test_changelog.py
+++ b/tests/test_changelog.py
@@ -1,6 +1,7 @@
 """Test the ChangeLog class."""
 
 import datetime
+from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any, cast
 from unittest.mock import MagicMock
@@ -8,6 +9,7 @@ from unittest.mock import MagicMock
 import pytest
 import typer
 from github import GithubException
+from github.GitRelease import GitRelease
 
 from github_changelog_md.changelog.changelog import ChangeLog, git_error
 from github_changelog_md.constants import ChangelogOptions, ExitErrors
@@ -201,6 +203,131 @@ def mock_repo() -> MagicMock:
         ),
     ]
     return mock_repo
+
+
+@dataclass
+class _FakeLabel:
+    name: str
+
+
+@dataclass
+class _FakeUser:
+    login: str
+
+    @property
+    def html_url(self) -> str:
+        return f"https://github.com/{self.login}"
+
+
+@dataclass
+class _FakeIssue:
+    number: int
+    title: str
+    user: _FakeUser
+    labels: list[_FakeLabel]
+    closed_by: _FakeUser | None = None
+    id: int | None = None
+    closed_at: datetime.datetime | None = None
+    pull_request: None = None
+
+    @property
+    def html_url(self) -> str:
+        return f"https://github.com/user/repo/issues/{self.number}"
+
+
+@dataclass
+class _FakePullRequest:
+    number: int
+    title: str
+    user: _FakeUser
+    labels: list[_FakeLabel]
+    id: int | None = None
+    merged_at: datetime.datetime | None = None
+
+    @property
+    def html_url(self) -> str:
+        return f"https://github.com/user/repo/pull/{self.number}"
+
+
+@dataclass(frozen=True)
+class _FakeRelease:
+    id: int
+    tag_name: str
+    title: str
+    created_at: datetime.datetime
+    body: str = ""
+
+    @property
+    def html_url(self) -> str:
+        return f"https://github.com/user/repo/releases/tag/{self.tag_name}"
+
+
+@dataclass
+class _OutputScenario:
+    releases: list[Any] = field(default_factory=list)
+    prs_by_release: dict[int, list[_FakePullRequest]] = field(
+        default_factory=dict
+    )
+    issues_by_release: dict[int, list[_FakeIssue]] = field(default_factory=dict)
+    unreleased_prs: list[_FakePullRequest] = field(default_factory=list)
+    unreleased_issues: list[_FakeIssue] = field(default_factory=list)
+
+
+def _date(year: int, month: int, day: int) -> datetime.datetime:
+    return datetime.datetime(year, month, day, tzinfo=datetime.timezone.utc)
+
+
+def _github_release(
+    release_id: int,
+    tag_name: str,
+    title: str,
+    created_at: datetime.datetime,
+    body: str = "",
+) -> GitRelease:
+    release = MagicMock(spec=GitRelease)
+    release.id = release_id
+    release.tag_name = tag_name
+    release.title = title
+    release.created_at = created_at
+    release.body = body
+    release.html_url = f"https://github.com/user/repo/releases/tag/{tag_name}"
+    return cast("GitRelease", release)
+
+
+def _render_changelog(
+    changelog: ChangeLog, mocker, scenario: _OutputScenario
+) -> str:
+    changelog.options["output_file"] = "CHANGELOG.md"
+    changelog.repo_data = MagicMock(
+        html_url="https://github.com/user/repo",
+        name="repo",
+    )
+    changelog.repo_releases = cast("Any", scenario.releases)
+    changelog.pr_by_release = cast("Any", scenario.prs_by_release)
+    changelog.issue_by_release = cast("Any", scenario.issues_by_release)
+    changelog.unreleased = cast("Any", scenario.unreleased_prs)
+    changelog.unreleased_issues = cast("Any", scenario.unreleased_issues)
+    changelog.sections = [
+        ("Breaking Changes", "breaking"),
+        ("Merged Pull Requests", None),
+        ("Enhancements", "enhancement"),
+        ("Bug Fixes", "bug"),
+        ("Refactoring", "refactor"),
+        ("Documentation", "documentation"),
+        ("Dependency Updates", "dependencies"),
+    ]
+    changelog.ignored_labels = ["duplicate", "invalid", "question", "wontfix"]
+
+    mock_path = mocker.patch("github_changelog_md.changelog.changelog.Path")
+    mock_path.cwd.return_value = Path("test_cwd")
+    file_handle = MagicMock()
+    mock_path.return_value.open.return_value.__enter__.return_value = (
+        file_handle
+    )
+
+    changelog.generate_changelog()
+
+    return "".join(call.args[0] for call in file_handle.write.call_args_list)
 
 
 class TestChangelog:
@@ -699,6 +826,252 @@ class TestChangelog:
         assert "Intro line\n\n" in rendered
         assert "This changelog was generated using" in rendered
         changelog.process_unreleased.assert_not_called()
+
+    def test_generate_changelog_renders_release_sections_golden(
+        self, mocker
+    ) -> None:
+        """Test a release renders issues and PR sections as Markdown."""
+        changelog = _build_changelog(mocker)
+        changelog.options["show_unreleased"] = False
+        changelog.options["ignore_items"] = [99]
+        changelog.options["max_depends"] = 1
+
+        release = _FakeRelease(
+            id=1,
+            tag_name="v1.0.0",
+            title="v1.0.0",
+            created_at=_date(2021, 1, 10),
+        )
+        issue = _FakeIssue(
+            number=7,
+            title="fixed issue",
+            user=_FakeUser("reporter"),
+            labels=[_FakeLabel("bug")],
+            closed_by=_FakeUser("maintainer"),
+        )
+        ignored_issue = _FakeIssue(
+            number=8,
+            title="support request",
+            user=_FakeUser("reporter"),
+            labels=[_FakeLabel("question")],
+            closed_by=_FakeUser("maintainer"),
+        )
+        pr_plain = _FakePullRequest(
+            number=2,
+            title="internal cleanup",
+            user=_FakeUser("dev-two"),
+            labels=[],
+        )
+        pr_feature = _FakePullRequest(
+            number=3,
+            title="add feature",
+            user=_FakeUser("dev-three"),
+            labels=[_FakeLabel("enhancement")],
+        )
+        pr_dep_old = _FakePullRequest(
+            number=4,
+            title="bump dep old",
+            user=_FakeUser("dependabot[bot]"),
+            labels=[_FakeLabel("dependencies")],
+        )
+        pr_dep_new = _FakePullRequest(
+            number=5,
+            title="bump dep new",
+            user=_FakeUser("dependabot[bot]"),
+            labels=[_FakeLabel("dependencies")],
+        )
+        pr_ignored = _FakePullRequest(
+            number=99,
+            title="hidden change",
+            user=_FakeUser("dev-hidden"),
+            labels=[],
+        )
+
+        rendered = _render_changelog(
+            changelog,
+            mocker,
+            _OutputScenario(
+                releases=[release],
+                prs_by_release={
+                    release.id: [
+                        pr_plain,
+                        pr_feature,
+                        pr_dep_old,
+                        pr_dep_new,
+                        pr_ignored,
+                    ]
+                },
+                issues_by_release={release.id: [issue, ignored_issue]},
+            ),
+        )
+
+        assert rendered == (
+            "# Changelog\n\n"
+            "## [v1.0.0](https://github.com/user/repo/releases/tag/v1.0.0) "
+            "(2021-01-10)\n\n"
+            "**Closed Issues**\n\n"
+            "- Fixed issue ([#7](https://github.com/user/repo/issues/7)) "
+            "by [maintainer](https://github.com/maintainer)\n\n"
+            "**Merged Pull Requests**\n\n"
+            "- Internal cleanup ([#2](https://github.com/user/repo/pull/2)) "
+            "by [dev-two](https://github.com/dev-two)\n\n"
+            "**Enhancements**\n\n"
+            "- Add feature ([#3](https://github.com/user/repo/pull/3)) "
+            "by [dev-three](https://github.com/dev-three)\n\n"
+            "**Dependency Updates**\n\n"
+            "- Bump dep new ([#5](https://github.com/user/repo/pull/5)) "
+            "by [dependabot[bot]](https://github.com/dependabot[bot])\n"
+            "- *and 1 more dependency updates*\n\n"
+            "---\n"
+            "*This changelog was generated using "
+            "[github-changelog-md](http://changelog.seapagan.net/) "
+            "by [Seapagan](https://github.com/seapagan)*\n"
+        )
+
+    def test_generate_changelog_renders_unreleased_golden(self, mocker) -> None:
+        """Test unreleased changes render to the current HEAD link."""
+        changelog = _build_changelog(
+            mocker,
+            {"release_text": [{"release": "unreleased", "text": "Preview"}]},
+        )
+        changelog.options["show_unreleased"] = True
+
+        rendered = _render_changelog(
+            changelog,
+            mocker,
+            _OutputScenario(
+                unreleased_prs=[
+                    _FakePullRequest(
+                        number=12,
+                        title="prepare next work",
+                        user=_FakeUser("dev-next"),
+                        labels=[],
+                    )
+                ],
+                unreleased_issues=[
+                    _FakeIssue(
+                        number=11,
+                        title="closed next issue",
+                        user=_FakeUser("reporter"),
+                        labels=[],
+                        closed_by=None,
+                    )
+                ],
+            ),
+        )
+
+        assert rendered == (
+            "# Changelog\n\n"
+            "## [Unreleased](https://github.com/user/repo/tree/HEAD)\n\n"
+            "Preview\n\n"
+            "**Closed Issues**\n\n"
+            "- Closed next issue "
+            "([#11](https://github.com/user/repo/issues/11))\n\n"
+            "**Merged Pull Requests**\n\n"
+            "- Prepare next work "
+            "([#12](https://github.com/user/repo/pull/12)) "
+            "by [dev-next](https://github.com/dev-next)\n\n"
+            "---\n"
+            "*This changelog was generated using "
+            "[github-changelog-md](http://changelog.seapagan.net/) "
+            "by [Seapagan](https://github.com/seapagan)*\n"
+        )
+
+    def test_generate_changelog_renders_release_text_variants_golden(
+        self, mocker
+    ) -> None:
+        """Test configured release text, yanked notes, and overrides render."""
+        changelog = _build_changelog(
+            mocker,
+            {
+                "release_text_before": [
+                    {"release": "v1.0.0", "text": "Before release"}
+                ],
+                "release_text": [{"release": "v1.0.0", "text": "Release note"}],
+                "release_overrides": [
+                    {"release": "v2.0.0", "text": "Override body\n"}
+                ],
+                "yanked": [{"release": "v1.0.0", "reason": "bad artifact"}],
+            },
+        )
+        changelog.options["show_unreleased"] = False
+        release_two = _github_release(
+            release_id=2,
+            tag_name="v2.0.0",
+            title="v2.0.0",
+            created_at=_date(2021, 2, 1),
+        )
+        release_one = _github_release(
+            release_id=1,
+            tag_name="v1.0.0",
+            title="Release One",
+            created_at=_date(2021, 1, 1),
+        )
+
+        rendered = _render_changelog(
+            changelog,
+            mocker,
+            _OutputScenario(releases=[release_two, release_one]),
+        )
+
+        assert rendered == (
+            "# Changelog\n\n"
+            "## [v2.0.0](https://github.com/user/repo/releases/tag/v2.0.0) "
+            "(2021-02-01)\n\n"
+            "Override body\n\n"
+            "[`Full Changelog`](https://github.com/user/repo/compare/"
+            "v1.0.0...v2.0.0) | [`Diff`](https://github.com/user/repo/"
+            "compare/v1.0.0...v2.0.0.diff) | [`Patch`](https://github.com/"
+            "user/repo/compare/v1.0.0...v2.0.0.patch)\n\n"
+            "---\n\n"
+            "Before release\n\n"
+            "---\n\n"
+            "## [v1.0.0](https://github.com/user/repo/releases/tag/v1.0.0) "
+            "(2021-01-01) **[`YANKED`]**\n\n"
+            "**This release has been removed for the following reason and "
+            "should not be used:**\n\n"
+            "- bad artifact\n\n"
+            "**_Release One_**\n\n"
+            "Release note\n\n"
+            "There were no merged pull requests or closed issues "
+            "for this release.\n\n"
+            "See the Full Changelog below for details.\n\n"
+            "---\n"
+            "*This changelog was generated using "
+            "[github-changelog-md](http://changelog.seapagan.net/) "
+            "by [Seapagan](https://github.com/seapagan)*\n"
+        )
+
+    def test_generate_changelog_renders_skip_and_no_releases_golden(
+        self, mocker
+    ) -> None:
+        """Test skipped releases and an otherwise empty changelog output."""
+        changelog = _build_changelog(mocker)
+        changelog.options["show_unreleased"] = False
+        changelog.options["show_depends"] = False
+        changelog.options["skip_releases"] = ["v1.0.0"]
+        skipped = _FakeRelease(
+            id=1,
+            tag_name="v1.0.0",
+            title="v1.0.0",
+            created_at=_date(2021, 1, 1),
+        )
+
+        rendered = _render_changelog(
+            changelog,
+            mocker,
+            _OutputScenario(releases=[skipped]),
+        )
+
+        assert rendered == (
+            "# Changelog\n\n"
+            "*Dependency updates are excluded from this changelog, "
+            "check each `Full Changelog` for details.*\n\n "
+            "---\n"
+            "*This changelog was generated using "
+            "[github-changelog-md](http://changelog.seapagan.net/) "
+            "by [Seapagan](https://github.com/seapagan)*\n"
+        )
 
     def test_flatten_ignores_with_extend_and_allowlist(self, mocker) -> None:
         """Test flatten_ignores combines defaults and removes allowed labels."""

--- a/tests/test_changelog.py
+++ b/tests/test_changelog.py
@@ -971,7 +971,7 @@ class TestChangelog:
             {"release": " v1.0.0 ", "text": " release text "}
         ]
         settings.release_overrides = [
-            {"release": " v1.0.0 ", "text": "override text"}
+            {"release": " v1.0.0 ", "text": " override text\n"}
         ]
 
         cache = build_release_text_cache(settings)
@@ -1344,6 +1344,44 @@ class TestChangelog:
         assert "Intro line\n\n" in rendered
         assert "This changelog was generated using" in rendered
         changelog.process_unreleased.assert_not_called()
+
+    def test_generate_changelog_normalizes_multiline_intro_spacing(
+        self, mocker
+    ) -> None:
+        """Test multiline intro text does not add an extra blank line."""
+        changelog = _build_changelog(mocker)
+        changelog.repo_data = MagicMock(
+            html_url="https://github.com/user/repo",
+            name="repo",
+        )
+        changelog.repo_releases = [
+            _release(
+                release_id=1,
+                tag_name="v1.0.0",
+                title="v1.0.0",
+                created_at=_date(2021, 1, 10),
+            )
+        ]
+        changelog.options["output_file"] = "CHANGELOG.md"
+        changelog.options["show_unreleased"] = False
+        changelog.settings.intro_text = "First paragraph\n\nSecond paragraph\n"
+
+        mock_path = mocker.patch(
+            "github_changelog_md.changelog.changelog.Path",
+        )
+        mock_path.cwd.return_value = Path("test_cwd")
+        file_handle = MagicMock()
+        mock_path.return_value.open.return_value.__enter__.return_value = (
+            file_handle
+        )
+
+        changelog.generate_changelog()
+
+        rendered = "".join(
+            call.args[0] for call in file_handle.write.call_args_list
+        )
+        assert "Second paragraph\n\n## [v1.0.0]" in rendered
+        assert "Second paragraph\n\n\n## [v1.0.0]" not in rendered
 
     def test_generate_changelog_renders_release_sections_golden(
         self, mocker

--- a/tests/test_changelog.py
+++ b/tests/test_changelog.py
@@ -1,6 +1,7 @@
 """Test the ChangeLog class."""
 
 import datetime
+from collections.abc import Mapping
 from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any, cast
@@ -11,12 +12,18 @@ import typer
 from github import GithubException
 from github.GitRelease import GitRelease
 
-from github_changelog_md.changelog.changelog import ChangeLog, git_error
+from github_changelog_md.changelog.changelog import ChangeLog
+from github_changelog_md.changelog.github_data import (
+    GitHubDataSource,
+    ItemCountColumn,
+    git_error,
+)
 from github_changelog_md.changelog.models import (
     ChangelogIssue,
     ChangelogLabel,
     ChangelogPullRequest,
     ChangelogRelease,
+    ChangelogRepository,
     ChangelogUser,
     issue_from_github,
     label_from_github,
@@ -46,7 +53,12 @@ def _default_options() -> ChangelogOptions:
     }
 
 
-def _build_changelog(mocker, settings_overrides=None) -> ChangeLog:
+def _build_changelog(
+    _mocker=None, settings_overrides: Mapping[str, object] | None = None
+) -> ChangeLog:
+    if settings_overrides is None and isinstance(_mocker, Mapping):
+        settings_overrides = _mocker
+
     settings = MagicMock()
     settings.github_pat = "1234"
     settings.yanked = None
@@ -62,20 +74,12 @@ def _build_changelog(mocker, settings_overrides=None) -> ChangeLog:
     settings.ignored_labels = None
     settings.extend_ignored = None
     settings.allowed_labels = None
+    data_source = MagicMock(spec=GitHubDataSource)
     if settings_overrides:
         for key, value in settings_overrides.items():
             setattr(settings, key, value)
 
-    mocker.patch(
-        "github_changelog_md.changelog.changelog.get_settings",
-        return_value=settings,
-    )
-    mocker.patch(
-        "github_changelog_md.changelog.changelog.Github",
-        return_value=MagicMock(),
-    )
-
-    return ChangeLog("repo", _default_options())
+    return ChangeLog("repo", _default_options(), settings, data_source)
 
 
 @pytest.fixture
@@ -230,6 +234,17 @@ class _OutputScenario:
     unreleased_issues: list[ChangelogIssue] = field(default_factory=list)
 
 
+@dataclass(frozen=True, slots=True)
+class _LazyGithubUser:
+    login: str
+    html_url: str
+
+    @property
+    def name(self) -> str:
+        msg = "name should not be read during item adaptation"
+        raise AssertionError(msg)
+
+
 def _date(year: int, month: int, day: int) -> datetime.datetime:
     return datetime.datetime(year, month, day, tzinfo=datetime.timezone.utc)
 
@@ -366,13 +381,24 @@ class TestChangelogModels:
         label = MagicMock(name="bug")
         label.name = "bug"
 
-        assert user_from_github(user) == ChangelogUser(
+        assert user_from_github(cast("Any", user)) == ChangelogUser(
             login="dev-user",
             html_url="https://github.com/dev-user",
-            name="Dev User",
         )
         assert user_from_github(None) is None
         assert label_from_github(label) == ChangelogLabel(name="bug")
+
+    def test_github_user_adapter_avoids_lazy_name_fetch(self) -> None:
+        """Test user conversion does not hydrate full profile data."""
+        user = _LazyGithubUser(
+            login="dev-user",
+            html_url="https://github.com/dev-user",
+        )
+
+        assert user_from_github(cast("Any", user)) == ChangelogUser(
+            login="dev-user",
+            html_url="https://github.com/dev-user",
+        )
 
     def test_github_release_adapter(self) -> None:
         """Test PyGithub release conversion."""
@@ -460,7 +486,6 @@ class TestChangelogModels:
             closed_by=ChangelogUser(
                 login="maintainer",
                 html_url="https://github.com/maintainer",
-                name="Maintainer",
             ),
         )
 
@@ -475,6 +500,271 @@ class TestChangelogModels:
             pull_request_from_github(pull_request)
         with pytest.raises(ValueError, match="Issue user cannot be None"):
             issue_from_github(issue)
+
+
+class TestGitHubDataSource:
+    """Tests for the GitHub data source boundary."""
+
+    def test_item_count_column_handles_unknown_total(self) -> None:
+        """Test progress counts omit invalid totals."""
+        expected_count = 7
+        task = MagicMock(completed=expected_count, total=None)
+
+        assert ItemCountColumn().render(task) == str(expected_count)
+
+    def test_fetch_methods_report_progress(self, mocker) -> None:
+        """Test GitHub item adaptation advances visible progress."""
+        expected_total = 3
+        mocker.patch("github_changelog_md.changelog.github_data.Github")
+        progress = MagicMock()
+        progress.__enter__.return_value = progress
+        progress.add_task.return_value = "task-id"
+        progress_cls = mocker.patch(
+            "github_changelog_md.changelog.github_data.Progress",
+            return_value=progress,
+        )
+        data_source = GitHubDataSource("token")
+        user = MagicMock()
+        user.login = "dev"
+        user.html_url = "https://github.com/dev"
+        user.name = None
+        repo_prs = MagicMock(totalCount=expected_total)
+        repo_prs.__iter__.return_value = iter(
+            [
+                MagicMock(
+                    id=pr_id,
+                    number=pr_id,
+                    title=f"pr {pr_id}",
+                    html_url=f"https://github.com/user/repo/pull/{pr_id}",
+                    user=user,
+                    labels=[],
+                    merged_at=_date(2021, 1, pr_id),
+                )
+                for pr_id in range(1, expected_total + 1)
+            ]
+        )
+        repo = MagicMock()
+        repo.get_pulls.return_value = repo_prs
+        data_source.repo_data = repo
+
+        assert len(data_source.get_closed_prs()) == expected_total
+        progress_cls.assert_called_once()
+        progress.add_task.assert_called_once_with(
+            "Loading PR details", total=expected_total
+        )
+        assert progress.advance.call_count == expected_total
+        progress.advance.assert_called_with("task-id")
+
+    def test_fetch_progress_handles_unknown_total(self, mocker) -> None:
+        """Test progress uses an unknown total when GitHub count is invalid."""
+        mocker.patch("github_changelog_md.changelog.github_data.Github")
+        progress = MagicMock()
+        progress.__enter__.return_value = progress
+        progress.add_task.return_value = "task-id"
+        mocker.patch(
+            "github_changelog_md.changelog.github_data.Progress",
+            return_value=progress,
+        )
+        data_source = GitHubDataSource("token")
+        user = MagicMock()
+        user.login = "reporter"
+        user.html_url = "https://github.com/reporter"
+        user.name = None
+        issue = MagicMock()
+        issue.id = 1
+        issue.number = 1
+        issue.title = "issue"
+        issue.html_url = "https://github.com/user/repo/issues/1"
+        issue.user = user
+        issue.labels = []
+        issue.closed_at = _date(2021, 1, 1)
+        issue.closed_by = user
+        issue.pull_request = None
+        repo_issues = MagicMock(totalCount=0)
+        repo_issues.__iter__.return_value = iter([issue])
+        repo = MagicMock()
+        repo.get_issues.return_value = repo_issues
+        data_source.repo_data = repo
+
+        assert len(data_source.get_closed_issues()) == 1
+        progress.add_task.assert_called_once_with(
+            "Loading issue candidates", total=None
+        )
+
+    def test_get_repo_data_returns_repository_model(self, mocker) -> None:
+        """Test repository lookup converts PyGithub data."""
+        git = MagicMock()
+        current_user = MagicMock(login="owner")
+        owner_user = MagicMock()
+        repo = MagicMock()
+        repo.name = "repo"
+        repo.full_name = "owner/repo"
+        repo.html_url = "https://github.com/owner/repo"
+        owner_user.get_repo.return_value = repo
+        git.get_user.side_effect = [current_user, owner_user]
+        mocker.patch(
+            "github_changelog_md.changelog.github_data.Github",
+            return_value=git,
+        )
+
+        data_source = GitHubDataSource("token")
+
+        assert data_source.get_repo_data("repo", None) == ChangelogRepository(
+            name="repo",
+            full_name="owner/repo",
+            html_url="https://github.com/owner/repo",
+        )
+        owner_user.get_repo.assert_called_once_with("repo")
+
+    def test_fetch_methods_return_domain_models(self, mocker) -> None:
+        """Test release, PR, issue, and first commit fetch paths."""
+        mocker.patch("github_changelog_md.changelog.github_data.Github")
+        data_source = GitHubDataSource("token")
+
+        label = MagicMock()
+        label.name = "bug"
+        user = MagicMock()
+        user.login = "dev"
+        user.html_url = "https://github.com/dev"
+        user.name = None
+        release = _github_release(
+            release_id=1,
+            tag_name="v1.0.0",
+            title="Version 1",
+            created_at=_date(2021, 1, 1),
+            body="Body",
+        )
+        pr = MagicMock()
+        pr.id = 2
+        pr.number = 20
+        pr.title = "fix pr"
+        pr.html_url = "https://github.com/user/repo/pull/20"
+        pr.user = user
+        pr.labels = [label]
+        pr.merged_at = _date(2021, 1, 2)
+        issue = MagicMock()
+        issue.id = 3
+        issue.number = 30
+        issue.title = "fix issue"
+        issue.html_url = "https://github.com/user/repo/issues/30"
+        issue.user = user
+        issue.labels = [label]
+        issue.closed_at = _date(2021, 1, 3)
+        issue.closed_by = user
+        issue.pull_request = None
+        first_commit = MagicMock()
+        first_commit.commit.committer.date = _date(2020, 1, 1)
+
+        repo = MagicMock()
+        repo.get_releases.return_value = MagicMock(totalCount=1)
+        repo.get_releases.return_value.__iter__.return_value = iter([release])
+        repo.get_pulls.return_value = MagicMock(totalCount=1)
+        repo.get_pulls.return_value.__iter__.return_value = iter([pr])
+        repo.get_issues.return_value = MagicMock(totalCount=1)
+        repo.get_issues.return_value.__iter__.return_value = iter([issue])
+        repo.get_commits.return_value.reversed = [first_commit]
+        data_source.repo_data = repo
+
+        assert data_source.get_repo_releases() == [
+            ChangelogRelease(
+                id=1,
+                tag_name="v1.0.0",
+                title="Version 1",
+                html_url="https://github.com/user/repo/releases/tag/v1.0.0",
+                created_at=_date(2021, 1, 1),
+                body="Body",
+            )
+        ]
+        assert data_source.get_closed_prs() == [
+            ChangelogPullRequest(
+                id=2,
+                number=20,
+                title="fix pr",
+                html_url="https://github.com/user/repo/pull/20",
+                user=_user("dev"),
+                labels=[_label("bug")],
+                merged_at=_date(2021, 1, 2),
+            )
+        ]
+        assert data_source.get_closed_issues() == [
+            ChangelogIssue(
+                id=3,
+                number=30,
+                title="fix issue",
+                html_url="https://github.com/user/repo/issues/30",
+                user=_user("dev"),
+                labels=[_label("bug")],
+                closed_at=_date(2021, 1, 3),
+                closed_by=_user("dev"),
+            )
+        ]
+        assert data_source.get_first_commit_date() == _date(2020, 1, 1)
+
+    def test_fetch_methods_route_github_errors(self, mocker) -> None:
+        """Test GitHub exceptions use the shared exit path."""
+        mocker.patch("github_changelog_md.changelog.github_data.Github")
+        data_source = GitHubDataSource("token")
+        data_source.repo_data = MagicMock()
+        data_source.repo_data.get_issues.side_effect = GithubException(
+            status=500,
+            data={"message": "boom"},
+        )
+        git_error_mock = mocker.patch(
+            "github_changelog_md.changelog.github_data.git_error",
+            side_effect=typer.Exit(ExitErrors.GIT_ERROR),
+        )
+
+        with pytest.raises(typer.Exit):
+            data_source.get_closed_issues()
+
+        git_error_mock.assert_called_once()
+
+    def test_other_github_errors_use_shared_exit_path(self, mocker) -> None:
+        """Test repository, release, and PR errors use shared error handling."""
+        expected_errors = ["repo error", "release error", "pull error"]
+        git = MagicMock()
+        git.get_user.side_effect = GithubException(
+            status=404,
+            data={"message": "missing"},
+        )
+        mocker.patch(
+            "github_changelog_md.changelog.github_data.Github",
+            return_value=git,
+        )
+        git_error_mock = mocker.patch(
+            "github_changelog_md.changelog.github_data.git_error",
+            side_effect=typer.Exit(ExitErrors.GIT_ERROR),
+        )
+        data_source = GitHubDataSource("token")
+
+        with pytest.raises(typer.Exit):
+            data_source.get_repo_data("repo", None)
+
+        repo = MagicMock()
+        data_source.repo_data = repo
+        repo.get_releases.side_effect = GithubException(
+            status=500,
+            data={"message": "release boom"},
+        )
+        with pytest.raises(typer.Exit):
+            data_source.get_repo_releases()
+
+        repo.get_pulls.side_effect = GithubException(
+            status=500,
+            data={"message": "pull boom"},
+        )
+        with pytest.raises(typer.Exit):
+            data_source.get_closed_prs()
+
+        assert git_error_mock.call_count == len(expected_errors)
+
+    def test_fetch_requires_repository_data(self, mocker) -> None:
+        """Test fetch methods require repository lookup first."""
+        mocker.patch("github_changelog_md.changelog.github_data.Github")
+        data_source = GitHubDataSource("token")
+
+        with pytest.raises(RuntimeError, match="Repository data"):
+            data_source.get_first_commit_date()
 
 
 class TestChangelog:
@@ -492,37 +782,6 @@ class TestChangelog:
 
         assert exc.value.args[0] == ExitErrors.GIT_ERROR
 
-    def test_no_pat_given(self, mocker, capsys) -> None:
-        """Test the no_pat_given method."""
-        mocker.patch(
-            "github_changelog_md.changelog.changelog.get_settings",
-            return_value="",
-        )
-        with pytest.raises(typer.Exit) as exc:
-            ChangeLog(
-                "repo",
-                {
-                    "user_name": None,
-                    "next_release": None,
-                    "show_unreleased": True,
-                    "show_depends": True,
-                    "output_file": "CHANGELOG.md",
-                    "contributors": False,
-                    "quiet": False,
-                    "skip_releases": None,
-                    "show_issues": True,
-                    "item_order": "newest-first",
-                    "ignore_items": None,
-                    "max_depends": 10,
-                    "show_diff": True,
-                    "show_patch": True,
-                },
-            )
-
-        output = capsys.readouterr()
-        assert exc.value.args[0] == ExitErrors.NO_PAT
-        assert "No GitHub PAT found in settings file" in output.err
-
     def test_run(
         self,
         mock_repo_data,
@@ -535,38 +794,13 @@ class TestChangelog:
             "github_changelog_md.changelog.changelog.header",
             autospec=True,
         )
-        mock_auth = MagicMock()
-        mocker.patch(
-            "github_changelog_md.changelog.changelog.Github",
-            autospec=True,
-            return_value=MagicMock(auth=mock_auth),
-        )
-
         mock_path = mocker.patch(
             "github_changelog_md.changelog.changelog.Path",
         )
         mock_path.return_value.open.return_value.__enter__.return_value = (
             MagicMock()
         )
-        changelog = ChangeLog(
-            "repo",
-            {
-                "user_name": "user",
-                "next_release": None,
-                "show_unreleased": True,
-                "show_depends": True,
-                "output_file": "CHANGELOG.md",
-                "contributors": False,
-                "quiet": False,
-                "skip_releases": None,
-                "show_issues": True,
-                "item_order": "newest-first",
-                "ignore_items": None,
-                "max_depends": 10,
-                "show_diff": True,
-                "show_patch": True,
-            },
-        )
+        changelog = _build_changelog(mocker)
         changelog.get_repo_data = MagicMock(return_value=mock_repo_data)
         changelog.get_closed_prs = MagicMock(
             return_value=mock_repo.get_pulls.return_value,
@@ -1584,10 +1818,6 @@ class TestChangelog:
             def __init__(self) -> None:
                 self.tag_name = "v1.0.0"
 
-        mocker.patch(
-            "github_changelog_md.changelog.changelog.GitRelease",
-            FakeRelease,
-        )
         out = MagicMock()
         changelog.show_release_text(out, cast("Any", FakeRelease()))
         rendered = "".join(call.args[0] for call in out.write.call_args_list)
@@ -1625,10 +1855,6 @@ class TestChangelog:
             def __init__(self, tag_name: str) -> None:
                 self.tag_name = tag_name
 
-        mocker.patch(
-            "github_changelog_md.changelog.changelog.GitRelease",
-            FakeRelease,
-        )
         out = MagicMock()
         changelog.generate_diff_url(
             out,
@@ -1677,10 +1903,7 @@ class TestChangelog:
         changelog = _build_changelog(mocker)
         changelog.repo_releases = []
         first_date = datetime.datetime(2020, 1, 1, tzinfo=datetime.timezone.utc)
-        first_commit = MagicMock()
-        first_commit.commit.committer.date = first_date
-        changelog.repo_data = MagicMock()
-        changelog.repo_data.get_commits.return_value.reversed = [first_commit]
+        changelog.data_source.get_first_commit_date.return_value = first_date
 
         assert changelog.get_latest_release_date() == first_date
 
@@ -1695,69 +1918,32 @@ class TestChangelog:
         assert filtered == [issue]
 
     def test_api_wrapper_methods_success_and_error_paths(self, mocker) -> None:
-        """Test API wrapper methods success/error branches."""
+        """Test API wrapper methods delegate to the data source."""
         changelog = _build_changelog(mocker)
-        changelog.repo_data = MagicMock()
-
-        issues = MagicMock(totalCount=2)
-        pulls = MagicMock(totalCount=3)
-        releases = MagicMock(totalCount=1)
-        releases.__iter__.return_value = iter([MagicMock(tag_name="v1.0.0")])
-        changelog.repo_data.get_issues.return_value = issues
-        changelog.repo_data.get_pulls.return_value = pulls
-        changelog.repo_data.get_releases.return_value = releases
+        issues = [_issue(1, "issue", "dev", [])]
+        pulls = [_pr(2, "pr", "dev", [])]
+        releases = [_release(3, "v1.0.0", "v1.0.0", _date(2021, 1, 1))]
+        changelog.data_source.get_closed_issues.return_value = issues
+        changelog.data_source.get_closed_prs.return_value = pulls
+        changelog.data_source.get_repo_releases.return_value = releases
 
         assert changelog.get_closed_issues() == issues
         assert changelog.get_closed_prs() == pulls
-        assert len(changelog.get_repo_releases()) == 1
+        assert changelog.get_repo_releases() == releases
 
-        git_error_mock = mocker.patch(
-            "github_changelog_md.changelog.changelog.git_error",
-            side_effect=typer.Exit(ExitErrors.GIT_ERROR),
-        )
-        changelog.repo_data.get_issues.side_effect = GithubException(
-            status=500,
-            data={"message": "boom"},
-        )
-        with pytest.raises(typer.Exit):
-            changelog.get_closed_issues()
-        assert git_error_mock.called
-
-        changelog.repo_data.get_pulls.side_effect = GithubException(
-            status=500,
-            data={"message": "boom"},
-        )
-        with pytest.raises(typer.Exit):
-            changelog.get_closed_prs()
-
-        changelog.repo_data.get_releases.side_effect = GithubException(
-            status=500,
-            data={"message": "boom"},
-        )
-        with pytest.raises(typer.Exit):
-            changelog.get_repo_releases()
-
-    def test_get_repo_data_success_and_error(self, mocker) -> None:
-        """Test get_repo_data success and exception handling."""
+    def test_get_repo_data_delegates_to_data_source(self, mocker) -> None:
+        """Test get_repo_data uses the configured data source."""
         changelog = _build_changelog(mocker)
         changelog.repo_name = "repo"
-        changelog.user = None
-        user_obj = MagicMock(login="owner")
-        repo_obj = MagicMock(full_name="owner/repo")
-        changelog.git = MagicMock()
-        changelog.git.get_user.return_value = user_obj
-        changelog.git.get_user.return_value.get_repo.return_value = repo_obj
-
-        assert changelog.get_repo_data() == repo_obj
-
-        git_error_mock = mocker.patch(
-            "github_changelog_md.changelog.changelog.git_error",
-            side_effect=typer.Exit(ExitErrors.GIT_ERROR),
+        changelog.user = "owner"
+        repo = ChangelogRepository(
+            name="repo",
+            full_name="owner/repo",
+            html_url="https://github.com/owner/repo",
         )
-        changelog.git.get_user.side_effect = GithubException(
-            status=404,
-            data={"message": "no repo"},
+        changelog.data_source.get_repo_data.return_value = repo
+
+        assert changelog.get_repo_data() == repo
+        changelog.data_source.get_repo_data.assert_called_once_with(
+            "repo", "owner"
         )
-        with pytest.raises(typer.Exit):
-            changelog.get_repo_data()
-        assert git_error_mock.called

--- a/tests/test_changelog.py
+++ b/tests/test_changelog.py
@@ -36,6 +36,10 @@ from github_changelog_md.changelog.models import (
     release_from_github,
     user_from_github,
 )
+from github_changelog_md.config.validation import (
+    ChangelogConfigError,
+    validate_changelog_options,
+)
 from github_changelog_md.constants import ChangelogOptions, ExitErrors
 
 
@@ -960,6 +964,28 @@ class TestChangelog:
             changelog.release_text_cache.release_overrides_by_release["v1.0.0"]
             == "override text"
         )
+
+    def test_build_release_lookup_rejects_missing_value_key(self) -> None:
+        """Test release lookup config requires the expected value key."""
+        with pytest.raises(
+            ChangelogConfigError,
+            match="release entry 1 is missing 'text'",
+        ):
+            ChangeLog.build_release_lookup(
+                [{"release": "v1.0.0"}],
+                value_key="text",
+            )
+
+    def test_build_release_lookup_rejects_empty_release(self) -> None:
+        """Test release lookup config requires a non-empty release tag."""
+        with pytest.raises(
+            ChangelogConfigError,
+            match="release entry 1 has an empty release tag",
+        ):
+            ChangeLog.build_release_lookup(
+                [{"release": "  ", "text": "Release note"}],
+                value_key="text",
+            )
 
     def test_check_yanked_uses_cache(self, mocker) -> None:
         """Test check_yanked reads from release_text_cache."""
@@ -1959,12 +1985,16 @@ class TestChangelog:
         rendered = "".join(call.args[0] for call in out.write.call_args_list)
         assert "Dependency Updates" not in rendered
 
-    def test_get_sorted_items_unknown_order_returns_input(self, mocker) -> None:
-        """Test get_sorted_items returns input for unknown ordering value."""
-        changelog = _build_changelog(mocker)
-        changelog.options["item_order"] = "keep"
-        items = [MagicMock(number=2), MagicMock(number=1)]
-        assert changelog.get_sorted_items(items) is items
+    def test_validate_changelog_options_rejects_unknown_order(self) -> None:
+        """Test invalid ordering is rejected before changelog rendering."""
+        options = _default_options()
+        options["item_order"] = "keep"
+
+        with pytest.raises(
+            ChangelogConfigError,
+            match="item_order must be one of",
+        ):
+            validate_changelog_options(options)
 
     def test_get_unreleased_cutoff_uses_first_commit_when_no_releases(
         self,

--- a/tests/test_changelog.py
+++ b/tests/test_changelog.py
@@ -12,6 +12,18 @@ from github import GithubException
 from github.GitRelease import GitRelease
 
 from github_changelog_md.changelog.changelog import ChangeLog, git_error
+from github_changelog_md.changelog.models import (
+    ChangelogIssue,
+    ChangelogLabel,
+    ChangelogPullRequest,
+    ChangelogRelease,
+    ChangelogUser,
+    issue_from_github,
+    label_from_github,
+    pull_request_from_github,
+    release_from_github,
+    user_from_github,
+)
 from github_changelog_md.constants import ChangelogOptions, ExitErrors
 
 
@@ -206,75 +218,87 @@ def mock_repo() -> MagicMock:
 
 
 @dataclass
-class _FakeLabel:
-    name: str
-
-
-@dataclass
-class _FakeUser:
-    login: str
-
-    @property
-    def html_url(self) -> str:
-        return f"https://github.com/{self.login}"
-
-
-@dataclass
-class _FakeIssue:
-    number: int
-    title: str
-    user: _FakeUser
-    labels: list[_FakeLabel]
-    closed_by: _FakeUser | None = None
-    id: int | None = None
-    closed_at: datetime.datetime | None = None
-    pull_request: None = None
-
-    @property
-    def html_url(self) -> str:
-        return f"https://github.com/user/repo/issues/{self.number}"
-
-
-@dataclass
-class _FakePullRequest:
-    number: int
-    title: str
-    user: _FakeUser
-    labels: list[_FakeLabel]
-    id: int | None = None
-    merged_at: datetime.datetime | None = None
-
-    @property
-    def html_url(self) -> str:
-        return f"https://github.com/user/repo/pull/{self.number}"
-
-
-@dataclass(frozen=True)
-class _FakeRelease:
-    id: int
-    tag_name: str
-    title: str
-    created_at: datetime.datetime
-    body: str = ""
-
-    @property
-    def html_url(self) -> str:
-        return f"https://github.com/user/repo/releases/tag/{self.tag_name}"
-
-
-@dataclass
 class _OutputScenario:
     releases: list[Any] = field(default_factory=list)
-    prs_by_release: dict[int, list[_FakePullRequest]] = field(
+    prs_by_release: dict[int, list[ChangelogPullRequest]] = field(
         default_factory=dict
     )
-    issues_by_release: dict[int, list[_FakeIssue]] = field(default_factory=dict)
-    unreleased_prs: list[_FakePullRequest] = field(default_factory=list)
-    unreleased_issues: list[_FakeIssue] = field(default_factory=list)
+    issues_by_release: dict[int, list[ChangelogIssue]] = field(
+        default_factory=dict
+    )
+    unreleased_prs: list[ChangelogPullRequest] = field(default_factory=list)
+    unreleased_issues: list[ChangelogIssue] = field(default_factory=list)
 
 
 def _date(year: int, month: int, day: int) -> datetime.datetime:
     return datetime.datetime(year, month, day, tzinfo=datetime.timezone.utc)
+
+
+def _user(login: str, name: str | None = None) -> ChangelogUser:
+    return ChangelogUser(
+        login=login,
+        html_url=f"https://github.com/{login}",
+        name=name,
+    )
+
+
+def _label(name: str) -> ChangelogLabel:
+    return ChangelogLabel(name=name)
+
+
+def _release(
+    release_id: int,
+    tag_name: str,
+    title: str,
+    created_at: datetime.datetime,
+    body: str | None = "",
+) -> ChangelogRelease:
+    return ChangelogRelease(
+        id=release_id,
+        tag_name=tag_name,
+        title=title,
+        html_url=f"https://github.com/user/repo/releases/tag/{tag_name}",
+        created_at=created_at,
+        body=body,
+    )
+
+
+def _pr(
+    number: int,
+    title: str,
+    user_login: str,
+    labels: list[ChangelogLabel],
+) -> ChangelogPullRequest:
+    return ChangelogPullRequest(
+        id=number,
+        number=number,
+        title=title,
+        html_url=f"https://github.com/user/repo/pull/{number}",
+        user=_user(user_login),
+        labels=labels,
+        merged_at=None,
+    )
+
+
+def _issue(
+    number: int,
+    title: str,
+    user_login: str,
+    labels: list[ChangelogLabel],
+    *,
+    closed_by_login: str | None = None,
+) -> ChangelogIssue:
+    return ChangelogIssue(
+        id=number,
+        number=number,
+        title=title,
+        html_url=f"https://github.com/user/repo/issues/{number}",
+        user=_user(user_login),
+        labels=labels,
+        closed_at=None,
+        closed_by=_user(closed_by_login) if closed_by_login else None,
+        pull_request=None,
+    )
 
 
 def _github_release(
@@ -328,6 +352,129 @@ def _render_changelog(
     changelog.generate_changelog()
 
     return "".join(call.args[0] for call in file_handle.write.call_args_list)
+
+
+class TestChangelogModels:
+    """Tests for changelog domain model adapters."""
+
+    def test_github_user_and_label_adapters(self) -> None:
+        """Test PyGithub user and label conversion."""
+        user = MagicMock()
+        user.login = "dev-user"
+        user.html_url = "https://github.com/dev-user"
+        user.name = "Dev User"
+        label = MagicMock(name="bug")
+        label.name = "bug"
+
+        assert user_from_github(user) == ChangelogUser(
+            login="dev-user",
+            html_url="https://github.com/dev-user",
+            name="Dev User",
+        )
+        assert user_from_github(None) is None
+        assert label_from_github(label) == ChangelogLabel(name="bug")
+
+    def test_github_release_adapter(self) -> None:
+        """Test PyGithub release conversion."""
+        release = _github_release(
+            release_id=1,
+            tag_name="v1.0.0",
+            title="Version 1",
+            created_at=_date(2021, 1, 1),
+            body="Release notes",
+        )
+
+        assert release_from_github(release) == ChangelogRelease(
+            id=1,
+            tag_name="v1.0.0",
+            title="Version 1",
+            html_url="https://github.com/user/repo/releases/tag/v1.0.0",
+            created_at=_date(2021, 1, 1),
+            body="Release notes",
+        )
+
+    def test_github_pull_request_adapter(self) -> None:
+        """Test PyGithub pull request conversion."""
+        label = MagicMock()
+        label.name = "enhancement"
+        user = MagicMock()
+        user.login = "dev-user"
+        user.html_url = "https://github.com/dev-user"
+        user.name = None
+        pull_request = MagicMock()
+        pull_request.id = 10
+        pull_request.number = 5
+        pull_request.title = "add feature"
+        pull_request.html_url = "https://github.com/user/repo/pull/5"
+        pull_request.user = user
+        pull_request.labels = [label]
+        pull_request.merged_at = _date(2021, 1, 2)
+
+        assert pull_request_from_github(pull_request) == ChangelogPullRequest(
+            id=10,
+            number=5,
+            title="add feature",
+            html_url="https://github.com/user/repo/pull/5",
+            user=ChangelogUser(
+                login="dev-user",
+                html_url="https://github.com/dev-user",
+            ),
+            labels=[ChangelogLabel(name="enhancement")],
+            merged_at=_date(2021, 1, 2),
+        )
+
+    def test_github_issue_adapter(self) -> None:
+        """Test PyGithub issue conversion."""
+        label = MagicMock()
+        label.name = "bug"
+        user = MagicMock()
+        user.login = "reporter"
+        user.html_url = "https://github.com/reporter"
+        user.name = None
+        closed_by = MagicMock()
+        closed_by.login = "maintainer"
+        closed_by.html_url = "https://github.com/maintainer"
+        closed_by.name = "Maintainer"
+        issue = MagicMock()
+        issue.id = 20
+        issue.number = 7
+        issue.title = "fix bug"
+        issue.html_url = "https://github.com/user/repo/issues/7"
+        issue.user = user
+        issue.labels = [label]
+        issue.closed_at = _date(2021, 1, 3)
+        issue.closed_by = closed_by
+        issue.pull_request = None
+
+        assert issue_from_github(issue) == ChangelogIssue(
+            id=20,
+            number=7,
+            title="fix bug",
+            html_url="https://github.com/user/repo/issues/7",
+            user=ChangelogUser(
+                login="reporter",
+                html_url="https://github.com/reporter",
+            ),
+            labels=[ChangelogLabel(name="bug")],
+            closed_at=_date(2021, 1, 3),
+            closed_by=ChangelogUser(
+                login="maintainer",
+                html_url="https://github.com/maintainer",
+                name="Maintainer",
+            ),
+        )
+
+    def test_github_item_adapters_require_users(self) -> None:
+        """Test PR and issue conversion rejects missing users."""
+        pull_request = MagicMock(user=None)
+        issue = MagicMock(user=None)
+
+        with pytest.raises(
+            ValueError, match="Pull request user cannot be None"
+        ):
+            pull_request_from_github(pull_request)
+        with pytest.raises(ValueError, match="Issue user cannot be None"):
+            issue_from_github(issue)
 
 
 class TestChangelog:
@@ -836,54 +983,54 @@ class TestChangelog:
         changelog.options["ignore_items"] = [99]
         changelog.options["max_depends"] = 1
 
-        release = _FakeRelease(
-            id=1,
+        release = _release(
+            release_id=1,
             tag_name="v1.0.0",
             title="v1.0.0",
             created_at=_date(2021, 1, 10),
         )
-        issue = _FakeIssue(
+        issue = _issue(
             number=7,
             title="fixed issue",
-            user=_FakeUser("reporter"),
-            labels=[_FakeLabel("bug")],
-            closed_by=_FakeUser("maintainer"),
+            user_login="reporter",
+            labels=[_label("bug")],
+            closed_by_login="maintainer",
         )
-        ignored_issue = _FakeIssue(
+        ignored_issue = _issue(
             number=8,
             title="support request",
-            user=_FakeUser("reporter"),
-            labels=[_FakeLabel("question")],
-            closed_by=_FakeUser("maintainer"),
+            user_login="reporter",
+            labels=[_label("question")],
+            closed_by_login="maintainer",
         )
-        pr_plain = _FakePullRequest(
+        pr_plain = _pr(
             number=2,
             title="internal cleanup",
-            user=_FakeUser("dev-two"),
+            user_login="dev-two",
             labels=[],
         )
-        pr_feature = _FakePullRequest(
+        pr_feature = _pr(
             number=3,
             title="add feature",
-            user=_FakeUser("dev-three"),
-            labels=[_FakeLabel("enhancement")],
+            user_login="dev-three",
+            labels=[_label("enhancement")],
         )
-        pr_dep_old = _FakePullRequest(
+        pr_dep_old = _pr(
             number=4,
             title="bump dep old",
-            user=_FakeUser("dependabot[bot]"),
-            labels=[_FakeLabel("dependencies")],
+            user_login="dependabot[bot]",
+            labels=[_label("dependencies")],
         )
-        pr_dep_new = _FakePullRequest(
+        pr_dep_new = _pr(
             number=5,
             title="bump dep new",
-            user=_FakeUser("dependabot[bot]"),
-            labels=[_FakeLabel("dependencies")],
+            user_login="dependabot[bot]",
+            labels=[_label("dependencies")],
         )
-        pr_ignored = _FakePullRequest(
+        pr_ignored = _pr(
             number=99,
             title="hidden change",
-            user=_FakeUser("dev-hidden"),
+            user_login="dev-hidden",
             labels=[],
         )
 
@@ -941,20 +1088,19 @@ class TestChangelog:
             mocker,
             _OutputScenario(
                 unreleased_prs=[
-                    _FakePullRequest(
+                    _pr(
                         number=12,
                         title="prepare next work",
-                        user=_FakeUser("dev-next"),
+                        user_login="dev-next",
                         labels=[],
                     )
                 ],
                 unreleased_issues=[
-                    _FakeIssue(
+                    _issue(
                         number=11,
                         title="closed next issue",
-                        user=_FakeUser("reporter"),
+                        user_login="reporter",
                         labels=[],
-                        closed_by=None,
                     )
                 ],
             ),
@@ -995,13 +1141,13 @@ class TestChangelog:
             },
         )
         changelog.options["show_unreleased"] = False
-        release_two = _github_release(
+        release_two = _release(
             release_id=2,
             tag_name="v2.0.0",
             title="v2.0.0",
             created_at=_date(2021, 2, 1),
         )
-        release_one = _github_release(
+        release_one = _release(
             release_id=1,
             tag_name="v1.0.0",
             title="Release One",
@@ -1050,8 +1196,8 @@ class TestChangelog:
         changelog.options["show_unreleased"] = False
         changelog.options["show_depends"] = False
         changelog.options["skip_releases"] = ["v1.0.0"]
-        skipped = _FakeRelease(
-            id=1,
+        skipped = _release(
+            release_id=1,
             tag_name="v1.0.0",
             title="v1.0.0",
             created_at=_date(2021, 1, 1),

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -9,6 +9,7 @@ import pytest
 from typer.testing import CliRunner
 
 from github_changelog_md.constants import ExitErrors
+from github_changelog_md.helpers import GitHubRemote
 from github_changelog_md.main import app
 
 if TYPE_CHECKING:
@@ -182,29 +183,60 @@ class TestCLI:
         _assert_changelog_called(mock_changelog, "test_repo", expected_options)
         mock_changelog_instance.run.assert_called_once()
 
-    def test_no_repo_specified_get_from_local_repo(
+    def test_no_repo_specified_get_from_local_github_repo(
         self,
         mocker: MockerFixture,
         mock_changelog: MockType,
     ) -> None:
         """Test the main function with no repo specified.
 
-        It should read the name from the local repo.
+        It should read the owner and repo from the local repo.
         """
         mock_changelog_instance = Mock()
         mock_changelog.return_value = mock_changelog_instance
 
         mocker.patch(
-            "github_changelog_md.main.get_repo_name",
-            return_value="test_local_repo",
+            "github_changelog_md.main.get_repo_remote",
+            return_value=GitHubRemote(owner="test_owner", repo="test_repo"),
         )
 
         runner = CliRunner()
         runner.invoke(app)
 
-        _assert_changelog_called(
-            mock_changelog, "test_local_repo", default_options
+        expected_options = cast(
+            "ChangelogOptions",
+            {**default_options, "user_name": "test_owner"},
         )
+        _assert_changelog_called(
+            mock_changelog,
+            "test_repo",
+            expected_options,
+        )
+        mock_changelog_instance.run.assert_called_once()
+
+    def test_explicit_repo_ignores_local_repo_owner(
+        self,
+        mocker: MockerFixture,
+        mock_changelog: MockType,
+    ) -> None:
+        """Test explicit repo keeps authenticated-user owner fallback."""
+        mock_changelog_instance = Mock()
+        mock_changelog.return_value = mock_changelog_instance
+
+        get_repo_remote = mocker.patch(
+            "github_changelog_md.main.get_repo_remote",
+            return_value=GitHubRemote(owner="local_owner", repo="local_repo"),
+        )
+
+        runner = CliRunner()
+        runner.invoke(app, ["--repo", "explicit_repo"])
+
+        _assert_changelog_called(
+            mock_changelog,
+            "explicit_repo",
+            default_options,
+        )
+        get_repo_remote.assert_not_called()
         mock_changelog_instance.run.assert_called_once()
 
     def test_no_repo_specified_and_no_local_repo_found(
@@ -220,7 +252,7 @@ class TestCLI:
         mock_changelog.return_value = mock_changelog_instance
 
         mocker.patch(
-            "github_changelog_md.main.get_repo_name",
+            "github_changelog_md.main.get_repo_remote",
             return_value=None,
         )
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -42,6 +42,31 @@ default_options: ChangelogOptions = {
 }
 
 
+def _settings_mock(**overrides: object) -> Mock:
+    """Return a settings-like mock with valid defaults."""
+    settings = Mock()
+    settings.github_pat = "1234"
+    settings.unreleased = True
+    settings.depends = True
+    settings.output_file = "CHANGELOG.md"
+    settings.contrib = False
+    settings.quiet = False
+    settings.skip_releases = None
+    settings.show_issues = True
+    settings.item_order = "newest-first"
+    settings.ignore_items = None
+    settings.max_depends = 10
+    settings.show_diff = True
+    settings.show_patch = True
+    settings.yanked = None
+    settings.release_text_before = None
+    settings.release_text = None
+    settings.release_overrides = None
+    for key, value in overrides.items():
+        setattr(settings, key, value)
+    return settings
+
+
 def _assert_changelog_called(
     mock_changelog: MockType, repo: str, options: ChangelogOptions
 ) -> None:
@@ -207,7 +232,7 @@ class TestCLI:
 
     def test_no_pat_given(self, mocker, mock_changelog: MockType) -> None:
         """Test missing PAT exits before constructing ChangeLog."""
-        settings = Mock()
+        settings = _settings_mock()
         del settings.github_pat
         mocker.patch(
             "github_changelog_md.main.get_settings", return_value=settings
@@ -218,4 +243,74 @@ class TestCLI:
 
         assert result.exit_code == ExitErrors.NO_PAT
         assert "No GitHub PAT found in settings file" in result.output
+        mock_changelog.assert_not_called()
+
+    def test_cli_rejects_invalid_item_order(
+        self,
+        mock_changelog: MockType,
+    ) -> None:
+        """Test invalid item ordering exits before constructing ChangeLog."""
+        runner = CliRunner()
+        result = runner.invoke(
+            app,
+            ["--repo", "test_repo", "--item-order", "sideways"],
+        )
+
+        assert result.exit_code == ExitErrors.INVALID_ACTION
+        assert "item_order must be one of" in result.output
+        mock_changelog.assert_not_called()
+
+    def test_cli_rejects_negative_max_depends(
+        self,
+        mock_changelog: MockType,
+    ) -> None:
+        """Test negative dependency limits exit before generation."""
+        runner = CliRunner()
+        result = runner.invoke(
+            app,
+            ["--repo", "test_repo", "--max-depends=-1"],
+        )
+
+        assert result.exit_code == ExitErrors.INVALID_ACTION
+        assert "max_depends must be greater than or equal to 0" in result.output
+        mock_changelog.assert_not_called()
+
+    def test_cli_accepts_zero_max_depends(
+        self,
+        mock_changelog: MockType,
+    ) -> None:
+        """Test zero is a valid dependency display limit."""
+        mock_changelog_instance = Mock()
+        mock_changelog.return_value = mock_changelog_instance
+
+        runner = CliRunner()
+        result = runner.invoke(
+            app,
+            ["--repo", "test_repo", "--max-depends=0"],
+        )
+
+        expected_options = cast(
+            "ChangelogOptions",
+            {**default_options, "max_depends": 0},
+        )
+        assert result.exit_code == 0
+        _assert_changelog_called(mock_changelog, "test_repo", expected_options)
+        mock_changelog_instance.run.assert_called_once()
+
+    def test_cli_rejects_invalid_release_text_config(
+        self,
+        mocker: MockerFixture,
+        mock_changelog: MockType,
+    ) -> None:
+        """Test malformed release text settings exit before generation."""
+        settings = _settings_mock(release_text=[{"release": "v1.0.0"}])
+        mocker.patch(
+            "github_changelog_md.main.get_settings", return_value=settings
+        )
+
+        runner = CliRunner()
+        result = runner.invoke(app, ["--repo", "test_repo"])
+
+        assert result.exit_code == ExitErrors.INVALID_ACTION
+        assert "release entry 1 is missing 'text'" in result.output
         mock_changelog.assert_not_called()

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -2,12 +2,13 @@
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING
-from unittest.mock import Mock
+from typing import TYPE_CHECKING, cast
+from unittest.mock import ANY, Mock
 
 import pytest
 from typer.testing import CliRunner
 
+from github_changelog_md.constants import ExitErrors
 from github_changelog_md.main import app
 
 if TYPE_CHECKING:
@@ -41,6 +42,13 @@ default_options: ChangelogOptions = {
 }
 
 
+def _assert_changelog_called(
+    mock_changelog: MockType, repo: str, options: ChangelogOptions
+) -> None:
+    """Assert the CLI created the changelog with orchestration dependencies."""
+    mock_changelog.assert_called_once_with(repo, options, ANY, ANY)
+
+
 @pytest.mark.usefixtures("config_file")
 class TestCLI:
     """Test class for the CLI functionality."""
@@ -64,10 +72,7 @@ class TestCLI:
 
         runner = CliRunner()
         runner.invoke(app, ["--repo", "test_repo"])
-        mock_changelog.assert_called_once_with(
-            "test_repo",
-            default_options,
-        )
+        _assert_changelog_called(mock_changelog, "test_repo", default_options)
         mock_changelog_instance.run.assert_called_once()
 
     @pytest.mark.parametrize(
@@ -99,11 +104,10 @@ class TestCLI:
         runner = CliRunner()
         runner.invoke(app, ["--repo", "test_repo", *cli_options[0]])
 
-        expected_options = {**default_options, **cli_options[1]}
-        mock_changelog.assert_called_once_with(
-            "test_repo",
-            expected_options,
+        expected_options = cast(
+            "ChangelogOptions", {**default_options, **cli_options[1]}
         )
+        _assert_changelog_called(mock_changelog, "test_repo", expected_options)
         mock_changelog_instance.run.assert_called_once()
 
     def test_cli_with_repo_and_user(self, mock_changelog: MockType) -> None:
@@ -114,11 +118,11 @@ class TestCLI:
         runner = CliRunner()
         runner.invoke(app, ["--repo", "test_repo", "--user", "test_user"])
 
-        expected_options = {**default_options, "user_name": "test_user"}
-        mock_changelog.assert_called_once_with(
-            "test_repo",
-            expected_options,
+        expected_options = cast(
+            "ChangelogOptions",
+            {**default_options, "user_name": "test_user"},
         )
+        _assert_changelog_called(mock_changelog, "test_repo", expected_options)
         mock_changelog_instance.run.assert_called_once()
 
     def test_cli_with_repo_and_user_and_next_release(
@@ -142,15 +146,15 @@ class TestCLI:
             ],
         )
 
-        expected_options = {
-            **default_options,
-            "user_name": "test_user",
-            "next_release": "v1.0",
-        }
-        mock_changelog.assert_called_once_with(
-            "test_repo",
-            expected_options,
+        expected_options = cast(
+            "ChangelogOptions",
+            {
+                **default_options,
+                "user_name": "test_user",
+                "next_release": "v1.0",
+            },
         )
+        _assert_changelog_called(mock_changelog, "test_repo", expected_options)
         mock_changelog_instance.run.assert_called_once()
 
     def test_no_repo_specified_get_from_local_repo(
@@ -173,9 +177,8 @@ class TestCLI:
         runner = CliRunner()
         runner.invoke(app)
 
-        mock_changelog.assert_called_once_with(
-            "test_local_repo",
-            default_options,
+        _assert_changelog_called(
+            mock_changelog, "test_local_repo", default_options
         )
         mock_changelog_instance.run.assert_called_once()
 
@@ -201,3 +204,18 @@ class TestCLI:
         assert "Could not find a local repository" in result.output
         mock_changelog.assert_not_called()
         mock_changelog_instance.run.assert_not_called()
+
+    def test_no_pat_given(self, mocker, mock_changelog: MockType) -> None:
+        """Test missing PAT exits before constructing ChangeLog."""
+        settings = Mock()
+        del settings.github_pat
+        mocker.patch(
+            "github_changelog_md.main.get_settings", return_value=settings
+        )
+
+        runner = CliRunner()
+        result = runner.invoke(app, ["--repo", "test_repo"])
+
+        assert result.exit_code == ExitErrors.NO_PAT
+        assert "No GitHub PAT found in settings file" in result.output
+        mock_changelog.assert_not_called()

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -72,7 +72,7 @@ def _assert_changelog_called(
     mock_changelog: MockType, repo: str, options: ChangelogOptions
 ) -> None:
     """Assert the CLI created the changelog with orchestration dependencies."""
-    mock_changelog.assert_called_once_with(repo, options, ANY, ANY)
+    mock_changelog.assert_called_once_with(repo, options, ANY, ANY, ANY)
 
 
 @pytest.mark.usefixtures("config_file")

--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -82,6 +82,7 @@ class TestHelpers:
             "https://gitlab.com/user/repo.git",
             "https://github.com/user",
             "https://github.com/user/repo/extra",
+            "https://github.com/user/.git",
             "not-a-url",
         ],
     )

--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -12,12 +12,15 @@ import pytest
 
 from github_changelog_md.constants import ExitErrors, SectionHeadings
 from github_changelog_md.helpers import (
+    GitHubRemote,
     cap_first_letter,
     get_app_version,
     get_index_of_tuple,
     get_repo_name,
+    get_repo_remote,
     get_section_name,
     header,
+    parse_github_remote,
     strip_first_alpha_char,
     title_unique,
 )
@@ -44,11 +47,67 @@ class TestHelpers:
     patch_get_toml = "github_changelog_md.helpers.get_toml_path"
     test_toml_path = "tests/data/pyproject.toml"
 
+    @pytest.mark.parametrize(
+        ("remote_url", "expected"),
+        [
+            (
+                "https://github.com/user/repo.git",
+                GitHubRemote(owner="user", repo="repo"),
+            ),
+            (
+                "https://github.com/user/repo",
+                GitHubRemote(owner="user", repo="repo"),
+            ),
+            (
+                "git@github.com:user/repo.git",
+                GitHubRemote(owner="user", repo="repo"),
+            ),
+            (
+                "ssh://git@github.com/user/repo.git",
+                GitHubRemote(owner="user", repo="repo"),
+            ),
+        ],
+    )
+    def test_parse_github_remote_supported_urls(
+        self,
+        remote_url: str,
+        expected: GitHubRemote,
+    ) -> None:
+        """Test supported GitHub remote URL forms."""
+        assert parse_github_remote(remote_url) == expected
+
+    @pytest.mark.parametrize(
+        "remote_url",
+        [
+            "https://gitlab.com/user/repo.git",
+            "https://github.com/user",
+            "https://github.com/user/repo/extra",
+            "not-a-url",
+        ],
+    )
+    def test_parse_github_remote_rejects_invalid_urls(
+        self,
+        remote_url: str,
+    ) -> None:
+        """Test unsupported remote URLs are ignored."""
+        assert parse_github_remote(remote_url) is None
+
+    def test_get_repo_remote_with_origin_remote(
+        self,
+        mocker: MockerFixture,
+    ) -> None:
+        """Test get_repo_remote with a valid origin remote URL."""
+        mocker.patch(
+            "github_changelog_md.helpers.subprocess.run",
+            return_value=MagicMock(stdout="https://github.com/user/repo.git\n"),
+        )
+        assert get_repo_remote() == GitHubRemote(owner="user", repo="repo")
+
     def test_get_repo_name_with_origin_remote(
         self,
         mocker: MockerFixture,
     ) -> None:
-        """Test get_repo_name function with a valid origin remote URL."""
+        """Test get_repo_name returns the repo from a valid origin remote."""
         mocker.patch(
             "github_changelog_md.helpers.subprocess.run",
             return_value=MagicMock(stdout="https://github.com/user/repo.git\n"),


### PR DESCRIPTION
This refactors the changelog generator around clearer internal boundaries while preserving the generated changelog output.

The branch adds golden output coverage, introduces internal changelog domain models, separates GitHub data access from core generation, extracts release bucketing, centralizes Markdown rendering, and moves validation into explicit config/option checks. It also improves local repository detection by parsing GitHub `origin` remotes as owner/repo, moves constructor setup work into factories or orchestration, and updates the CLI option declarations to the current Typer `Annotated` style.

User-visible changes include clearer validation failures for invalid `item_order`, negative `max_depends`, and malformed release text config. `max_depends = 0` is now explicitly valid and documented. Running the tool inside a GitHub checkout without `--repo` now uses the parsed remote owner as well as the repo name.